### PR TITLE
fix(skip-2fa): 跳过修改密码后的跳转按登录来源判断，第三方系统不再误跳教务处

### DIFF
--- a/src/features/skip-2fa/id-scu-skip-change-passwd.ts
+++ b/src/features/skip-2fa/id-scu-skip-change-passwd.ts
@@ -2,6 +2,9 @@ import { initIdCaptchaOcr } from "~features/ocr/id-captcha"
 import { getSetting } from "~script/config"
 
 async function initChangePasswd() {
+  // 同步记录进入统一认证时的原始 URL（document_start 时），用于判断登录来源
+  // （如 flylatex 等第三方系统经 shibboleth 进入，URL 会带 redirect_uri/sp_code）
+  const entryUrl = window.location.href;
   try {
     const setting = await getSetting();
 
@@ -14,8 +17,39 @@ async function initChangePasswd() {
     // 仅在用户开启"禁用修改密码弹窗"开关时注入拦截逻辑
     const enabled = setting && setting.passwordPopupSwitch;
     if (enabled) {
-      const redirectTo = 'https://id.scu.edu.cn/enduser/sp/sso/scdxplugin_jwt23?enterpriseId=scdx&target_url=index';
+      const redirectToZhjw = 'https://id.scu.edu.cn/enduser/sp/sso/scdxplugin_jwt23?enterpriseId=scdx&target_url=index';
       let stopped = false;
+
+      // 是否从插件的 zhjw 重定向 / popup 登录进入（这类"跳过修改密码"后应回到教务处）
+      function isZhjwOrigin(): boolean {
+        return /scdxplugin_jwt23/.test(entryUrl) && /target_url=index/.test(entryUrl);
+      }
+
+      // 解析第三方系统（如 flylatex shibboleth）登录页 URL 中的 redirect_uri（base64 编码）
+      function getThirdPartyRedirect(): string | null {
+        try {
+          const hash = entryUrl.split('#')[1] || '';
+          const query = hash.split('?')[1] || entryUrl.split('?')[1] || '';
+          const uri = new URLSearchParams(query).get('redirect_uri');
+          if (!uri) return null;
+          try {
+            return window.atob(decodeURIComponent(uri));
+          } catch (e) {
+            return decodeURIComponent(uri);
+          }
+        } catch (e) {
+          return null;
+        }
+      }
+
+      // 计算"跳过修改密码"后的跳转目标：
+      // 仅插件的 zhjw 重定向（或 popup 登录）才跳回教务处；第三方系统跳回其 redirect_uri
+      function computeRedirectTarget(): string {
+        if (isZhjwOrigin()) return redirectToZhjw;
+        const thirdParty = getThirdPartyRedirect();
+        if (thirdParty) return thirdParty;
+        return redirectToZhjw;
+      }
 
       function removeAllListeners(){
         try{
@@ -33,7 +67,8 @@ async function initChangePasswd() {
         try{
           // stop monitoring before redirecting
           removeAllListeners();
-          try{ window.location.replace(redirectTo); }catch(e){ window.location.href = redirectTo; }
+          const target = computeRedirectTarget();
+          try{ window.location.replace(target); }catch(e){ window.location.href = target; }
         }catch(e){}
       }
 


### PR DESCRIPTION
### 背景 / 问题

当用户在统一身份认证登录后，若系统要求修改密码（进入 `https://id.scu.edu.cn/frontend/login#/modifyPassword?type=needModifyPasswordOfPwdExpire`），插件的"**禁用修改密码弹窗**"功能会检测到该页面并重定向到教务处（`scdxplugin_jwt23?target_url=index`）。

原实现**无条件**重定向到教务处，未区分登录来源，导致：

- 用户从 **第三方系统**（经 shibboleth/`sp_code`/`redirect_uri` 进入统一认证）登录后，也会被带到教务处
- 而期望行为是：**只有从插件的 zhjw 重定向（或 popup 登录）进入时**才跳回教务处；第三方系统应跳回其来源

### 修改内容

文件：id-scu-skip-change-passwd.ts

1. 在 `document_start` 同步记录进入统一认证时的**原始 URL**（`entryUrl`），用于判断登录来源
2. 新增 `computeRedirectTarget()`，"跳过修改密码"后的跳转目标按来源决定：

| 来源 | 判断条件 | 跳转目标 |
|------|---------|---------|
| 插件的 zhjw 重定向 / popup 登录 | URL 含 `scdxplugin_jwt23` + `target_url=index` | 教务处（保持原行为）|
| 第三方系统 | URL 含 `redirect_uri`（base64） | 解码并跳回其 `redirect_uri` |
| 其他 | 兜底 | 教务处 |

### 影响范围

仅影响"禁用修改密码弹窗"开关开启时，登录后被要求修改密码的跳转行为。不影响跳2FA（2FA 接口拦截）及教务处正常登录流程。