### PR TITLE
feat(ocr): 新增 zhjw 登录页验证码自动识别

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@plasmohq/storage": "^1.15.0",
+    "@scu-plus/zhjw-captcha-ocr": "github:meteor-liu-xinyu/zhjw-captcha-ocr",
     "@zumer/snapdom": "^2.23.1",
     "chart.js": "^4.5.1",
     "chartjs-plugin-annotation": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@plasmohq/storage':
         specifier: ^1.15.0
         version: 1.15.0(react@18.2.0)
+      '@scu-plus/zhjw-captcha-ocr':
+        specifier: github:meteor-liu-xinyu/zhjw-captcha-ocr
+        version: git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git#f3907953d5b369a98c3cf10603704108308966d7
       '@zumer/snapdom':
         specifier: ^2.23.1
         version: 2.23.1
@@ -73,10 +76,6 @@ packages:
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.29.8':
     resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
@@ -115,11 +114,6 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
@@ -133,16 +127,8 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.29.8':
     resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.8':
@@ -1414,6 +1400,10 @@ packages:
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
 
+  '@scu-plus/zhjw-captcha-ocr@git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git#f3907953d5b369a98c3cf10603704108308966d7':
+    resolution: {commit: f3907953d5b369a98c3cf10603704108308966d7, repo: https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git, type: git}
+    version: 1.0.0
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1763,11 +1753,6 @@ packages:
   abortcontroller-polyfill@1.7.8:
     resolution: {integrity: sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==}
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
@@ -1813,11 +1798,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.33:
-    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.9:
     resolution: {integrity: sha512-cp447VUsGS07+n1Dqf7YSQ8maeJrjEhaDxTm1ZefbqDtypHBC5GzGMQbklR6IPR13Y8OAJRHZWEMtZipJLCttg==}
     engines: {node: '>=6.0.0'}
@@ -1839,11 +1819,6 @@ packages:
 
   browserslist@4.22.1:
     resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1887,9 +1862,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
@@ -2110,9 +2082,6 @@ packages:
   dotenv@7.0.0:
     resolution: {integrity: sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==}
     engines: {node: '>=6'}
-
-  electron-to-chromium@1.5.364:
-    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
 
   electron-to-chromium@1.5.399:
     resolution: {integrity: sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==}
@@ -2708,11 +2677,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2749,10 +2713,6 @@ packages:
   node-object-hash@3.1.1:
     resolution: {integrity: sha512-A32kRGjXtwQ+uSa3GrXiCl8HVFY0Jy6IiKFO7UjagAKSaOOrruxB2Qf/w7TP5QtNfB3uOiHTu3cjhp8k/C0PCg==}
     engines: {node: '>=16', pnpm: '>=8'}
-
-  node-releases@2.0.46:
-    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
-    engines: {node: '>=18'}
 
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
@@ -2859,10 +2819,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
@@ -3298,14 +3254,14 @@ snapshots:
   '@babel/core@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
-      '@babel/types': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -3314,14 +3270,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/generator@7.29.7':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.8':
     dependencies:
@@ -3335,7 +3283,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -3343,8 +3291,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
-      '@babel/types': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -3353,7 +3301,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3366,11 +3314,7 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.8':
     dependencies:
@@ -3381,20 +3325,8 @@ snapshots:
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/traverse@7.29.7(supports-color@7.2.0)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.8(supports-color@7.2.0)':
     dependencies:
@@ -3407,11 +3339,6 @@ snapshots:
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.8':
     dependencies:
@@ -4916,6 +4843,8 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@scu-plus/zhjw-captcha-ocr@git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git#f3907953d5b369a98c3cf10603704108308966d7': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/is@5.6.0': {}
@@ -5159,7 +5088,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -5192,14 +5121,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.25
       source-map-js: 1.2.1
     optional: true
 
@@ -5252,9 +5181,6 @@ snapshots:
 
   abortcontroller-polyfill@1.7.8: {}
 
-  acorn@8.16.0:
-    optional: true
-
   acorn@8.18.0: {}
 
   ansi-escapes@4.3.2:
@@ -5288,8 +5214,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.33: {}
-
   baseline-browser-mapping@2.11.9: {}
 
   binary-extensions@2.3.0: {}
@@ -5308,14 +5232,6 @@ snapshots:
       electron-to-chromium: 1.5.399
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.22.1)
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.33
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.364
-      node-releases: 2.0.46
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   browserslist@4.28.7:
     dependencies:
@@ -5365,8 +5281,6 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001793: {}
 
   caniuse-lite@1.0.30001806: {}
 
@@ -5577,8 +5491,6 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@7.0.0: {}
-
-  electron-to-chromium@1.5.364: {}
 
   electron-to-chromium@1.5.399: {}
 
@@ -6132,9 +6044,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12:
-    optional: true
-
   nanoid@3.3.16: {}
 
   needle@2.9.1(supports-color@7.2.0):
@@ -6166,8 +6075,6 @@ snapshots:
     optional: true
 
   node-object-hash@3.1.1: {}
-
-  node-releases@2.0.46: {}
 
   node-releases@2.0.51: {}
 
@@ -6337,13 +6244,6 @@ snapshots:
       postcss: 8.5.25
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
 
   postcss@8.5.25:
     dependencies:
@@ -6622,7 +6522,7 @@ snapshots:
   terser@5.46.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true
@@ -6708,12 +6608,6 @@ snapshots:
   update-browserslist-db@1.2.3(browserslist@4.22.1):
     dependencies:
       browserslist: 4.22.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   '@parcel/watcher': true
+  '@scu-plus/zhjw-captcha-ocr@git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git#f3907953d5b369a98c3cf10603704108308966d7': true
   '@swc/core': true
   esbuild: true
   lmdb: true

--- a/src/contents/zhjw-login.ts
+++ b/src/contents/zhjw-login.ts
@@ -1,5 +1,6 @@
 import type { PlasmoCSConfig } from "plasmo"
 import { initRedirectLogin } from "~features/redirect-login"
+import { initZhjwCaptchaOcr } from "~features/ocr/zhjw-captcha-ocr"
 
 export const config: PlasmoCSConfig = {
     matches: [
@@ -10,3 +11,7 @@ export const config: PlasmoCSConfig = {
 }
 
 initRedirectLogin().catch((e) => console.warn("SCU+: 登录重定向初始化失败", e));
+
+// 登录重定向关闭时，zhjw 登录页自带验证码 → 启动本地 OCR 识别。
+// 若重定向开启，页面会立即跳走，OCR 初始化自然作废，无副作用。
+initZhjwCaptchaOcr().catch((e) => console.warn("SCU+: zhjw 验证码 OCR 初始化失败", e));

--- a/src/features/ocr/zhjw-captcha-ocr.ts
+++ b/src/features/ocr/zhjw-captcha-ocr.ts
@@ -1,0 +1,200 @@
+/**
+ * zhjw 验证码 OCR 的浏览器侧封装：
+ *   1. 通过外部 OCR 包识别验证码（模型与 CNN 推理已移至独立仓库）
+ *   2. 预处理（去黑线、灰度反色、缩放）与推理由外部包完成
+ *   3. 本文件只负责 zhjw 登录页的 DOM 集成：查找验证码图片/输入框、自动识别并填写
+ *
+ * 若外部 OCR 包尚未接入（见 `docs/ocr-package-integration.md`），
+ * 识别自动降级为空串，不影响登录页其余功能。
+ */
+import { getZhjwCaptchaRecognizer, warmupZhjwOcr } from "~features/ocr/zhjw-ocr-adapter"
+import { getSetting } from "~script/config"
+
+export { warmupZhjwOcr }
+
+/**
+ * 识别 zhjw 验证码图片，返回 4 位字符。
+ * 未接入外部 OCR 包、或置信度不足、或图片不可用时返回空串。
+ */
+export async function ocrZhjw(imageElement: HTMLImageElement): Promise<string> {
+  const recognizer = getZhjwCaptchaRecognizer();
+  if (!recognizer) {
+    console.warn("[SCU+] zhjw 验证码识别未接入（外部 OCR 包未安装），跳过识别");
+    return "";
+  }
+  try {
+    return await recognizer.recognize(imageElement);
+  } catch (e) {
+    console.warn("[SCU+] zhjw 验证码识别失败", e);
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 内容脚本集成
+// ---------------------------------------------------------------------------
+
+/**
+ * 初始化 zhjw 登录页验证码自动识别。
+ * 在 zhjw 登录页（未重定向到统一认证时）自动识别并填写验证码。
+ */
+export async function initZhjwCaptchaOcr(): Promise<void> {
+  const savedSettings = await getSetting();
+  if (!savedSettings.ocrSwitch) return;
+
+  // 后台预加载模型
+  warmupZhjwOcr();
+
+  let running = false;
+  let timer: number | null = null;
+  let lastCaptchaSrc = "";
+  let lastRecognizedSrc = "";
+  let retryCount = 0;
+
+  const isVisible = (el: Element | null): el is HTMLElement => {
+    if (!(el instanceof HTMLElement)) return false;
+    const style = window.getComputedStyle(el);
+    return style.display !== "none" && style.visibility !== "hidden" && el.offsetParent !== null;
+  };
+
+  /** 查找验证码图片 */
+  const getCaptchaImage = (): HTMLImageElement | null => {
+    const selectors = [
+      "img#captchaImg",
+      "img.captcha",
+      "img[src*='captcha']",
+      "img[src*='verifyCode']",
+      "img[src*='imgcode']",
+      "img[src*='Captcha']",
+    ];
+    for (const sel of selectors) {
+      const img = document.querySelector<HTMLImageElement>(sel);
+      if (img && isVisible(img)) return img;
+    }
+    // 兜底：查找登录表单内的图片
+    const form = document.querySelector("form");
+    if (form) {
+      const img = form.querySelector<HTMLImageElement>("img");
+      if (img && isVisible(img)) return img;
+    }
+    return null;
+  };
+
+  /** 查找验证码输入框 */
+  const getCaptchaInput = (): HTMLInputElement | null => {
+    const selectors = [
+      "input#captcha",
+      "input[name='captcha']",
+      "input[name='validateCode']",
+      "input[name='verifyCode']",
+      "input[placeholder*='验证码']",
+      "input[placeholder*='captcha' i]",
+    ];
+    for (const sel of selectors) {
+      const input = document.querySelector<HTMLInputElement>(sel);
+      if (input && isVisible(input)) return input;
+    }
+    // 兜底：查找登录表单内较短的文本输入框（验证码输入框通常较短）
+    const form = document.querySelector("form");
+    if (form) {
+      const inputs = Array.from(form.querySelectorAll<HTMLInputElement>("input[type='text']"));
+      const visible = inputs.filter(isVisible);
+      // 排除用户名输入框（通常 name/placeholder 包含 user/账号/学号）
+      const captchaLike = visible.filter((i) => {
+        const name = (i.name + " " + i.placeholder + " " + i.id).toLowerCase();
+        return !name.includes("user") && !name.includes("账号") && !name.includes("学号") && !name.includes("username");
+      });
+      if (captchaLike.length > 0) return captchaLike[captchaLike.length - 1];
+    }
+    return null;
+  };
+
+  const scheduleRun = (delay = 120) => {
+    if (timer) window.clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      void runOcr();
+    }, delay);
+  };
+
+  const bindCaptchaLoadListener = (img: HTMLImageElement) => {
+    const marker = "__scuZhjwOcrLoadBound";
+    if ((img as any)[marker]) return;
+    (img as any)[marker] = true;
+    img.addEventListener("load", () => scheduleRun(60));
+  };
+
+  const runOcr = async (): Promise<void> => {
+    if (running) return;
+    running = true;
+    try {
+      const img = getCaptchaImage();
+      if (!img) return;
+      bindCaptchaLoadListener(img);
+
+      if (!img.complete || !(img.naturalWidth || img.width) || !(img.naturalHeight || img.height)) {
+        return;
+      }
+
+      const input = getCaptchaInput();
+      if (!input || !isVisible(input)) return;
+
+      const src = img.currentSrc || img.src || "";
+      if (src !== lastCaptchaSrc) {
+        if (lastRecognizedSrc && input.value.trim().length === 4) {
+          input.value = "";
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          input.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+        lastCaptchaSrc = src;
+        lastRecognizedSrc = "";
+        retryCount = 0;
+      }
+      if (input.value.trim().length > 0 && !lastRecognizedSrc) return;
+      if (src === lastRecognizedSrc && input.value.trim().length === 4) return;
+
+      const resultRaw = await ocrZhjw(img);
+      const result = String(resultRaw || "").replace(/\s+/g, "");
+
+      if (result.length !== 4) {
+        if (retryCount < 3) {
+          retryCount++;
+          window.setTimeout(() => img.click(), 350);
+        }
+        return;
+      }
+
+      retryCount = 0;
+      input.value = result;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      lastRecognizedSrc = src;
+    } catch (e) {
+      // 偶发失败，静默等待下次触发
+    } finally {
+      running = false;
+    }
+  };
+
+  document.addEventListener("click", (e) => {
+    const target = e.target as Element | null;
+    if (!target) return;
+    if (target instanceof HTMLImageElement) {
+      const src = (target.src || "").toLowerCase();
+      if (src.includes("captcha") || src.includes("verifycode") || src.includes("imgcode")) {
+        scheduleRun(120);
+      }
+    }
+  }, true);
+
+  try {
+    const mo = new MutationObserver(() => scheduleRun(120));
+    mo.observe(document.body || document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["class", "style", "src"]
+    });
+  } catch (e) {}
+
+  scheduleRun(200);
+}

--- a/src/features/ocr/zhjw-ocr-adapter.ts
+++ b/src/features/ocr/zhjw-ocr-adapter.ts
@@ -1,0 +1,46 @@
+/**
+ * zhjw 验证码识别器适配层。
+ *
+ * 模型的 CNN 推理引擎与权重已迁移到独立的 OCR 包
+ * `@scu-plus/zhjw-captcha-ocr`（见 `docs/ocr-package-integration.md`），
+ * 本文件负责创建并持有识别器实例，供登录页集成代码调用。
+ */
+import {
+  createZhjwCaptchaOcr,
+  type ZhjwCaptchaRecognizer,
+} from "@scu-plus/zhjw-captcha-ocr"
+
+export type { ZhjwCaptchaRecognizer }
+
+let recognizer: ZhjwCaptchaRecognizer | null = null
+
+/** 惰性创建识别器实例 */
+function ensureRecognizer(): ZhjwCaptchaRecognizer | null {
+  if (!recognizer) {
+    try {
+      recognizer = createZhjwCaptchaOcr()
+    } catch (e) {
+      console.warn("[SCU+] zhjw OCR 识别器创建失败", e)
+    }
+  }
+  return recognizer
+}
+
+/** 获取当前识别器；创建失败时返回 null（识别降级） */
+export function getZhjwCaptchaRecognizer(): ZhjwCaptchaRecognizer | null {
+  return ensureRecognizer()
+}
+
+/** 覆盖/注入识别器实例（调试或自定义实现时使用） */
+export function setZhjwCaptchaRecognizer(impl: ZhjwCaptchaRecognizer | null): void {
+  recognizer = impl
+}
+
+/** 预热识别器（若可用） */
+export function warmupZhjwOcr(): void {
+  try {
+    ensureRecognizer()?.warmup()
+  } catch (e) {
+    console.warn("[SCU+] zhjw OCR 预热失败", e)
+  }
+}


### PR DESCRIPTION
## 概述

为 zhjw（教务处）登录页新增**验证码自动识别**功能。模型与推理引擎不内置在本仓库，而是通过**外部 OCR 包** `@scu-plus/zhjw-captcha-ocr`（独立仓库）提供，浏览器内本地推理、无网络依赖。

- 本 PR 为**新增功能**，main 之前没有任何 zhjw 验证码识别（main 只有统一身份认证的验证码识别，且为传统 CV 实现，本次未改动）。

## 改动内容（提交 `68f475d`）

| 文件 | 说明 |
|------|------|
| zhjw-ocr-adapter.ts | 新增：对接外部 OCR 包的适配层（`ZhjwCaptchaRecognizer` 接口）|
| zhjw-captcha-ocr.ts | 新增：zhjw 登录页 DOM 集成（定位验证码图/输入框、自动识别并填写、失败重试）|
| zhjw-login.ts | 初始化 zhjw 验证码 OCR（仅当登录重定向关闭时生效）|
| package.json | 新增依赖 `@scu-plus/zhjw-captcha-ocr`（GitHub 链接）|
| pnpm-workspace.yaml | `allowBuilds` 放行外部包构建脚本 |
| pnpm-lock.yaml | 依赖更新 |

## 外部 OCR 包

- **包名**：`@scu-plus/zhjw-captcha-ocr`（`1.0.0`）
- **仓库**：https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr
- **内容**：zhjw 验证码 CNN 推理引擎 + int8 模型权重（`.scuocr`），浏览器内本地推理
- **接口**：`createZhjwCaptchaOcr()` → `{ warmup(), recognize(img) }`，返回 4 位字符、置信度不足返回空串

## 包体积影响

| 指标 | main | 本 PR | 差异 |
|------|------|------|------|
| `chrome-mv3-prod.zip` | 395.3 KB | 492.1 KB | **+96.8 KB** |
| `zhjw-login.*.js` | 10.5 KB | 23.2 KB | +12.7 KB |
| 模型 asset（`.scuocr`）| 无 | 108.1 KB（压缩后约 +84 KB）| 新增 |

新增体积主要来自**模型权重**。

## 验证

- `pnpm build` / `pnpm build --zip` 构建通过
- 模型 asset 已正确打包进扩展，`zhjw-login` 产物包含外部包推理逻辑
- 外部包通过 GitHub 链接安装时自动构建（`prepare` 脚本），并适配 Parcel 打包（`new URL(..., import.meta.url)` 引入权重）

## 后续可讨论

- 模型独立仓库维护、通过 GitHub 链接引入的依赖方式，是否考虑发布到 npm registry / 私有源