### PR TITLE
fix: 完善课表 ICS 导出的周次获取与日期推算

### DIFF
--- a/src/features/course-table/ics.ts
+++ b/src/features/course-table/ics.ts
@@ -71,8 +71,10 @@ function calcFirstMonday(currentWeek: number): Date {
     const mondayOfThisWeek = new Date(today);
     mondayOfThisWeek.setHours(0, 0, 0, 0);
     mondayOfThisWeek.setDate(today.getDate() - daysSinceMonday);
+    // 周次序列 -2,-1,1,2,... 无 0 周：负周次按 week 直接偏移，正周次从第 1 周起 (week - 1)
+    const offset = currentWeek > 0 ? currentWeek - 1 : currentWeek;
     const firstMonday = new Date(mondayOfThisWeek);
-    firstMonday.setDate(mondayOfThisWeek.getDate() - (currentWeek - 1) * 7);
+    firstMonday.setDate(mondayOfThisWeek.getDate() - offset * 7);
     return firstMonday;
 }
 

--- a/src/features/course-table/ics.ts
+++ b/src/features/course-table/ics.ts
@@ -67,14 +67,18 @@ function parseCurrentWeek(): number | null {
 function calcFirstMonday(currentWeek: number): Date {
     const today = new Date();
     const dayOfWeek = today.getDay();
-    const daysSinceMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-    const mondayOfThisWeek = new Date(today);
-    mondayOfThisWeek.setHours(0, 0, 0, 0);
-    mondayOfThisWeek.setDate(today.getDate() - daysSinceMonday);
+    // 校历每周第一天是周日：周日=0, 周一=1, ..., 周六=6
+    const daysSinceSunday = dayOfWeek;
+    const sundayOfThisWeek = new Date(today);
+    sundayOfThisWeek.setHours(0, 0, 0, 0);
+    sundayOfThisWeek.setDate(today.getDate() - daysSinceSunday);
     // 周次序列 -2,-1,1,2,... 无 0 周：负周次按 week 直接偏移，正周次从第 1 周起 (week - 1)
     const offset = currentWeek > 0 ? currentWeek - 1 : currentWeek;
-    const firstMonday = new Date(mondayOfThisWeek);
-    firstMonday.setDate(mondayOfThisWeek.getDate() - offset * 7);
+    const firstSunday = new Date(sundayOfThisWeek);
+    firstSunday.setDate(sundayOfThisWeek.getDate() - offset * 7);
+    // firstMonday 取第一周的周一（classDay 1=周一）
+    const firstMonday = new Date(firstSunday);
+    firstMonday.setDate(firstSunday.getDate() + 1);
     return firstMonday;
 }
 

--- a/src/features/course-table/ics.ts
+++ b/src/features/course-table/ics.ts
@@ -58,7 +58,7 @@ function parseCurrentWeek(): number | null {
     if (!spans?.length) return null;
     for (const span of spans) {
         const text = span.textContent || '';
-        const match = text.match(/第(\d+)周/);
+        const match = text.match(/第(-?\d+)周/);
         if (match) return parseInt(match[1], 10);
     }
     return null;
@@ -176,7 +176,9 @@ function generateIcs(rawData: any, firstMonday: Date): string {
     lines.push('BEGIN:VCALENDAR');
     lines.push('VERSION:2.0');
     lines.push('PRODID:-//SCU Plus//CN');
-    lines.push('X-WR-CALNAME:SCU Plus 课表');
+    const semesterName = getSemesterName(rawData);
+    const calendarName = semesterName === '课表' ? 'SCU Plus 课表' : `${semesterName} SCU Plus 课表`;
+    lines.push(`X-WR-CALNAME:${calendarName}`);
     lines.push('BEGIN:VTIMEZONE');
     lines.push('TZID:Asia/Shanghai');
     lines.push('BEGIN:STANDARD');
@@ -453,6 +455,10 @@ export async function exportScheduleIcs() {
 
         let firstMonday: Date;
         const currentWeek = parseCurrentWeek();
+        if (currentWeek === 0) {
+            message.info('当前周次无效（第 0 周不存在）');
+            return;
+        }
         if (currentWeek) {
             if (!isCurrentSemester) {
                 const currentFirstMonday = calcFirstMonday(currentWeek);

--- a/src/features/course-table/ics.ts
+++ b/src/features/course-table/ics.ts
@@ -352,6 +352,71 @@ function showFirstMondayModal(currentFirstMonday: Date, prefillDate: Date | null
     });
 }
 
+// ── 弹窗：无法从页面获取周次时手动输入第一周周一日期 ──────────
+
+function showFirstMondayDateModal(): Promise<Date | null> {
+    return new Promise(resolve => {
+        const overlay = document.createElement('div');
+        overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:99999;display:flex;align-items:center;justify-content:center;';
+        overlay.innerHTML = `
+            <div style="background:#fff;border-radius:8px;padding:24px;min-width:380px;box-shadow:0 4px 12px rgba(0,0,0,0.15);">
+                <h5 style="margin:0 0 16px;font-size:16px;">无法自动获取当前周次，请选择第一周周一日期</h5>
+                <div style="margin-bottom:12px;">
+                    <label style="display:block;padding:8px 0;">第一周周一日期</label>
+                    <input type="date" id="scu-plus-first-monday-date" style="width:100%;box-sizing:border-box;padding:6px 8px;border:1px solid #ccc;border-radius:4px;">
+                </div>
+                <div style="text-align:right;margin-top:16px;">
+                    <button id="scu-plus-modal-cancel" style="padding:6px 16px;margin-right:8px;border:1px solid #ccc;border-radius:4px;background:#fff;cursor:pointer;">取消</button>
+                    <button id="scu-plus-modal-confirm" style="padding:6px 16px;border:none;border-radius:4px;background:#428bca;color:#fff;cursor:pointer;">确定</button>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(overlay);
+
+        const dateInput = overlay.querySelector('#scu-plus-first-monday-date') as HTMLInputElement;
+        const confirmBtn = overlay.querySelector('#scu-plus-modal-confirm') as HTMLButtonElement;
+        const cancelBtn = overlay.querySelector('#scu-plus-modal-cancel') as HTMLButtonElement;
+
+        dateInput.focus();
+
+        const cleanup = () => {
+            try { document.body.removeChild(overlay); } catch (e) { }
+        };
+
+        const submit = () => {
+            const val = dateInput.value;
+            if (!val) {
+                message.info('请选择日期');
+                return;
+            }
+            const result = new Date(val + 'T00:00:00');
+            if (isNaN(result.getTime())) {
+                message.info('日期格式无效');
+                return;
+            }
+            cleanup();
+            resolve(result);
+        };
+
+        confirmBtn.addEventListener('click', submit);
+        dateInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') submit();
+        });
+
+        cancelBtn.addEventListener('click', () => {
+            cleanup();
+            resolve(null);
+        });
+
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) {
+                cleanup();
+                resolve(null);
+            }
+        });
+    });
+}
+
 // ── 下载 ────────────────────────────────────────────────────────
 
 function downloadIcsFile(content: string, filename: string) {
@@ -370,12 +435,6 @@ function downloadIcsFile(content: string, filename: string) {
 
 export async function exportScheduleIcs() {
     try {
-        const currentWeek = parseCurrentWeek();
-        if (!currentWeek) {
-            message.info('无法获取当前周数，请确认页面已加载学期信息');
-            return;
-        }
-
         const { planCode, isCurrentSemester } = parsePlanCode();
 
         let res: Response;
@@ -393,14 +452,22 @@ export async function exportScheduleIcs() {
         const rawData = JSON.parse(text);
 
         let firstMonday: Date;
-        if (!isCurrentSemester) {
-            const currentFirstMonday = calcFirstMonday(currentWeek);
-            const prefillDate = planCode ? getDefaultFirstMonday(planCode) : null;
-            const chosen = await showFirstMondayModal(currentFirstMonday, prefillDate);
+        const currentWeek = parseCurrentWeek();
+        if (currentWeek) {
+            if (!isCurrentSemester) {
+                const currentFirstMonday = calcFirstMonday(currentWeek);
+                const prefillDate = planCode ? getDefaultFirstMonday(planCode) : null;
+                const chosen = await showFirstMondayModal(currentFirstMonday, prefillDate);
+                if (!chosen) return;
+                firstMonday = chosen;
+            } else {
+                firstMonday = calcFirstMonday(currentWeek);
+            }
+        } else {
+            // 无法从页面获取周次：让用户直接输入第一周周一的日期
+            const chosen = await showFirstMondayDateModal();
             if (!chosen) return;
             firstMonday = chosen;
-        } else {
-            firstMonday = calcFirstMonday(currentWeek);
         }
 
         const semesterName = getSemesterName(rawData);


### PR DESCRIPTION
## 描述
针对课表 ICS 导出在学期开始前后（负周次）、周日、以及页面未加载学期信息等场景下的周次处理问题，做了一系列修复与增强：

1. 当无法从 navbar 获取周次时，要求用户弹窗输入周次。
2. 开学的时候会出现`第-1周`，`-1`指`第1周`的前一周，正确解析负数周。
3.  **周日制修正**: 如果是在周日导出 ICS 文件，那么导出的课程会提前一周，确认校历每周第一天为周日，`calcFirstMonday` 从周一制改为周日制——周次为 1 且当天是周日时，第一周周一为次日（+1 天），而非此前算出的六天前。
4. **ICS 日历标题**：`X-WR-CALNAME` 带学期名前缀（如 `2026-2027秋 SCU Plus 课表`）

## 改动类型
- [] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 代码重构

## 测试
- [x] 已本地测试
- [ ] 需要人工测试

## 截图（如有）
<img width="426" height="80" alt="俄" src="https://github.com/user-attachments/assets/070f2a38-2e06-4618-974f-7eb6a33c6107" />
