### PR TITLE
Fix/code review

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -10,20 +10,22 @@ on:
         description: '要发布的版本 tag（如 v2.3.0）'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-24.04
-    env:
-      BUILD_FIREFOX: true # whether to build firefox plugin
-    
+
     steps:
+      # workflow_dispatch 时必须检出 inputs.tag 指定的提交，而不是触发分支的 HEAD
       - name: Checkout code
-        run: git clone --branch=${{ github.ref_name }} https://github.com/${{ github.repository }}.git .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -40,7 +42,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "22.13"
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -50,7 +52,6 @@ jobs:
         run: pnpm build --zip
 
       - name: Build firefox plugin
-        if: env.BUILD_FIREFOX == 'true'
         run: pnpm build --zip --target=firefox-mv3
 
       - name: Create Release & Upload Assets
@@ -60,8 +61,7 @@ jobs:
           tag_name: ${{ inputs.tag || github.ref_name }}
           name: Release ${{ env.title }}
           body: ${{ env.release_notes }}
-          # 注意：BUILD_FIREFOX 固定为 true，firefox zip 始终构建；
-          # 若日后改为按需构建，需相应调整此文件列表
+          # chrome 与 firefox 的 zip 始终构建并上传
           files: |
             ./build/chrome-mv3-prod.zip
             ./build/firefox-mv3-prod.zip

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "2.3.3",
   "description": "四川大学教务系统增强插件",
   "packageManager": "pnpm@11.18.0",
+  "engines": {
+    "node": ">=22.13 <23"
+  },
   "author": "jeanhua",
   "download": "https://github.com/The-Brotherhood-of-SCU/scu-plus/releases",
   "projectLink": "https://github.com/The-Brotherhood-of-SCU/scu-plus",
@@ -13,6 +16,7 @@
     "dev": "plasmo dev",
     "build": "plasmo build",
     "package": "plasmo package",
+    "typecheck": "tsc --noEmit",
     "build:firefox:amo": "bash scripts/build-firefox-amo.sh",
     "package:amo-source": "bash scripts/package-amo-source.sh"
   },
@@ -23,16 +27,16 @@
     "chart.js": "^4.5.1",
     "chartjs-plugin-annotation": "^3.1.0",
     "decimal.js": "^10.6.0",
-    "plasmo": "0.90.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "4.7.1",
     "@types/chrome": "0.1.38",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "baseline-browser-mapping": "^2.11.9",
+    "plasmo": "0.90.5",
     "prettier": "3.8.1",
     "typescript": "6.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "version": "2.3.3",
   "description": "四川大学教务系统增强插件",
   "packageManager": "pnpm@11.18.0",
-  "engines": {
-    "node": ">=22.13 <23"
-  },
   "author": "jeanhua",
   "download": "https://github.com/The-Brotherhood-of-SCU/scu-plus/releases",
   "projectLink": "https://github.com/The-Brotherhood-of-SCU/scu-plus",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^1.15.0
         version: 1.15.0(react@18.2.0)
       '@scu-plus/zhjw-captcha-ocr':
-        specifier: git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git
+        specifier: github:meteor-liu-xinyu/zhjw-captcha-ocr
         version: git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git#bcddfde6a4a9d5edf8ebd3881bbdbc51417d338a
       '@zumer/snapdom':
         specifier: ^2.23.1
@@ -26,9 +26,6 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
-      plasmo:
-        specifier: 0.90.5
-        version: 0.90.5(@swc/core@1.15.47(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/node@25.5.0)(lodash@4.18.1)(postcss@8.5.25)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(supports-color@7.2.0)(terser@5.46.1)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -43,14 +40,17 @@ importers:
         specifier: 0.1.38
         version: 0.1.38
       '@types/react':
-        specifier: 19.2.14
-        version: 19.2.14
+        specifier: ^18.3.28
+        version: 18.3.31
       '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.14)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       baseline-browser-mapping:
         specifier: ^2.11.9
         version: 2.11.9
+      plasmo:
+        specifier: 0.90.5
+        version: 0.90.5(@swc/core@1.15.47(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/node@25.5.0)(lodash@4.18.1)(postcss@8.5.25)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(supports-color@7.2.0)(terser@5.46.1)
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -1686,13 +1686,16 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
-    peerDependencies:
-      '@types/react': ^19.2.0
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@types/relateurl@0.2.33':
     resolution: {integrity: sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==}
@@ -5067,12 +5070,15 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
+  '@types/prop-types@15.7.15': {}
 
-  '@types/react@19.2.14':
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
     dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   '@types/relateurl@0.2.33': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
   '@parcel/watcher': true
-  '@scu-plus/zhjw-captcha-ocr@git+https://github.com/meteor-liu-xinyu/zhjw-captcha-ocr.git#bcddfde6a4a9d5edf8ebd3881bbdbc51417d338a': true
+  '@scu-plus/zhjw-captcha-ocr@github:meteor-liu-xinyu/zhjw-captcha-ocr': true
   '@swc/core': true
   esbuild: true
   lmdb: true
@@ -8,6 +8,7 @@ allowBuilds:
   sharp: true
 onlyBuiltDependencies:
   - '@parcel/watcher'
+  - '@scu-plus/zhjw-captcha-ocr@github:meteor-liu-xinyu/zhjw-captcha-ocr'
   - '@swc/core'
   - esbuild
   - lmdb

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,125 +1,140 @@
 export { }
 
 import { Actions } from './constants/actions';
+import { getSetting } from './script/config';
+import { resolveAvatarRedirectUrl } from './common/avatar';
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.action == Actions.REQUEST) {
-        // 抽象写法，主要是chrome的api设计太狗屎了
-        (async () => {
-            try {
-                // 加超时，避免请求挂起导致 MV3 service worker 回收后消息通道静默断开
-                const response = await fetch(message.url,{redirect:"follow",signal:AbortSignal.timeout(15000),headers:{
-                    "accept":message.accept?message.accept:'*/*'
-                }});
-                if (response.ok) {
-                    const text = await response.text();
-                    sendResponse({ success: true, data: text });
-                } else {
-                    sendResponse({ success: false, error: `HTTP Error: ${response.status}` });
+// REQUEST 代理的显式白名单（与 manifest host_permissions 的实际用途对应：
+// 教务/校历请求、更新检查、QQ 头像），不依赖 manifest 的隐含约束
+const PROXY_ALLOWED_HOSTS = ['scu.edu.cn', 'api.github.com', 'q1.qlogo.cn'];
+
+function isProxyAllowedUrl(rawUrl: unknown): boolean {
+    if (typeof rawUrl !== 'string') return false;
+    try {
+        const url = new URL(rawUrl);
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') return false;
+        const host = url.hostname;
+        return PROXY_ALLOWED_HOSTS.some(allowed =>
+            host === allowed || host.endsWith(`.${allowed}`)
+        );
+    } catch {
+        return false;
+    }
+}
+
+interface RuntimeMessage {
+    action?: string;
+    url?: unknown;
+    accept?: unknown;
+}
+
+chrome.runtime.onMessage.addListener((message: RuntimeMessage, sender, sendResponse) => {
+    switch (message?.action) {
+        case Actions.REQUEST: {
+            // 抽象写法，主要是chrome的api设计太狗屎了
+            (async () => {
+                if (!isProxyAllowedUrl(message.url)) {
+                    sendResponse({ success: false, error: 'URL not allowed' });
+                    return;
                 }
-            } catch (error) {
-                sendResponse({ success: false, error: error.message });
+                try {
+                    // 加超时，避免请求挂起导致 MV3 service worker 回收后消息通道静默断开
+                    const response = await fetch(message.url as string, {
+                        redirect: "follow",
+                        signal: AbortSignal.timeout(15000),
+                        headers: {
+                            "accept": typeof message.accept === 'string' ? message.accept : '*/*'
+                        }
+                    });
+                    if (response.ok) {
+                        const text = await response.text();
+                        sendResponse({ success: true, data: text });
+                    } else {
+                        sendResponse({ success: false, error: `HTTP Error: ${response.status}` });
+                    }
+                } catch (error) {
+                    sendResponse({ success: false, error: (error as Error).message });
+                }
+            })();
+            return true;
+        }
+        case Actions.UPDATE_AVATAR: {
+            // 头像重定向仅接受 http(s) 目标（DNR 会把教务头像请求改写到该地址）
+            if (typeof message.url === 'string' && /^https?:\/\//.test(message.url)) {
+                updateAvatarRedirectRules(message.url)
+                    .catch((e) => console.warn("更新头像重定向规则失败:", e));
+            } else {
+                console.warn("SCU+: 忽略非法的头像重定向地址");
             }
-        })();
-        return true;
-    }
-    else if(message.action==Actions.UPDATE_AVATAR){
-        updateAvatarRedirectRules(message.url).catch((e) => console.warn("更新头像重定向规则失败:", e))
-        return false;
-    }
-    else if(message.action==Actions.REMOVE_AVATAR_REDIRECTION){
-        removeAvatarRedirectRules().catch((e) => console.warn("移除头像重定向规则失败:", e))
-        return false;
-    }else if(message.action==Actions.OPEN_SETTINGS){
-        const url = chrome.runtime.getURL("options.html");
-        chrome.tabs.create({ url: url });
-        return false;
+            return false;
+        }
+        case Actions.REMOVE_AVATAR_REDIRECTION: {
+            removeAvatarRedirectRules().catch((e) => console.warn("移除头像重定向规则失败:", e));
+            return false;
+        }
+        case Actions.OPEN_SETTINGS: {
+            const url = chrome.runtime.getURL("options.html");
+            chrome.tabs.create({ url: url });
+            return false;
+        }
+        default: {
+            console.warn("SCU+: 收到未知消息", message);
+            return false;
+        }
     }
 });
 
+// DNR 动态规则持久存在，但设置随时可能被修改，或上次规则更新时 SW 被回收而失败。
+// 启动 / 扩展更新时按当前设置重放一次，保证规则与设置一致。
+async function syncAvatarRedirectRules(): Promise<void> {
+    try {
+        const setting = await getSetting();
+        const url = setting.avatarSwitch
+            ? resolveAvatarRedirectUrl(setting.avatarSource, setting.avatarInfo)
+            : null;
+        if (url) {
+            await updateAvatarRedirectRules(url);
+        } else {
+            await removeAvatarRedirectRules();
+        }
+    } catch (e) {
+        console.warn("SCU+: 同步头像重定向规则失败", e);
+    }
+}
+chrome.runtime.onStartup.addListener(syncAvatarRedirectRules);
+chrome.runtime.onInstalled.addListener(syncAvatarRedirectRules);
 
-async function updateAvatarRedirectRules(redirectUrl) {
-    // 构建动态规则
-    const newRules = [{
-        id: 1,
-        priority: 1,
-        action: {
-            type: 'redirect',
-            redirect: {
-                url: redirectUrl
-            }
-        },
-        condition: {
-            urlFilter: '*://zhjw.scu.edu.cn/*main/queryStudent/img',
-            resourceTypes: ['image']
-        }
-    },
-    {
-        id: 2,
-        priority: 1,
-        action: {
-            type: 'redirect',
-            redirect: {
-                url: redirectUrl
-            }
-        },
-        condition: {
-            urlFilter: '*://zhjw.scu.edu.cn/*img/head/man.png',
-            resourceTypes: ['image']
-        }
-    },
-    {
-        id: 3,
-        priority: 1,
-        action: {
-            type: 'redirect',
-            redirect: {
-                url: redirectUrl
-            }
-        },
-        condition: {
-            urlFilter: '*://zhjw.scu.edu.cn/*img/head/woman.png',
-            resourceTypes: ['image']
-        }
-    },
-    {
-        id: 4,
-        priority: 1,
-        action: {
-            type: 'redirect',
-            redirect: {
-                url: redirectUrl
-            }
-        },
-        condition: {
-            urlFilter: '*://zhjw.scu.edu.cn/*student/rollInfo/img',
-            resourceTypes: ['image']
-        }
-    },
-    {
-        id: 5,
-        priority: 1,
-        action: {
-            type: 'redirect',
-            redirect: {
-                url: redirectUrl
-            }
-        },
-        condition: {
-            urlFilter: '*://zhjw.scu.edu.cn/img/icon/default_photo.png',
-            resourceTypes: ['image']
-        }
-    },
+// 头像重定向的 5 个目标都是教务系统的默认头像接口，仅 urlFilter 不同
+const AVATAR_RULE_IDS = [1, 2, 3, 4, 5];
+const AVATAR_URL_FILTERS = [
+    '*://zhjw.scu.edu.cn/*main/queryStudent/img',
+    '*://zhjw.scu.edu.cn/*img/head/man.png',
+    '*://zhjw.scu.edu.cn/*img/head/woman.png',
+    '*://zhjw.scu.edu.cn/*student/rollInfo/img',
+    '*://zhjw.scu.edu.cn/img/icon/default_photo.png',
 ];
-    // 更新规则
-    await (chrome.declarativeNetRequest as any).updateDynamicRules({
-        removeRuleIds: [1,2,3,4,5],
-        addRules: newRules as any
+
+async function updateAvatarRedirectRules(redirectUrl: string) {
+    const addRules = AVATAR_URL_FILTERS.map((urlFilter, i) => ({
+        id: AVATAR_RULE_IDS[i],
+        priority: 1,
+        action: {
+            type: 'redirect' as const,
+            redirect: { url: redirectUrl }
+        },
+        condition: {
+            urlFilter,
+            resourceTypes: ['image' as const]
+        }
+    }));
+    await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: AVATAR_RULE_IDS,
+        addRules
     });
 }
 
-function removeAvatarRedirectRules(){
+function removeAvatarRedirectRules() {
     return chrome.declarativeNetRequest.updateDynamicRules({
-        removeRuleIds: [1,2,3,4,5],
+        removeRuleIds: AVATAR_RULE_IDS,
     });
 }

--- a/src/common/avatar.ts
+++ b/src/common/avatar.ts
@@ -1,0 +1,18 @@
+/**
+ * 根据头像设置构造教务头像重定向的目标 URL。
+ * 设置页发送消息和 background 启动时对账 DNR 规则共用此逻辑。
+ * 非法输入（QQ 号非数字、自定义地址非 http(s)）返回 null，由调用方决定回退行为。
+ */
+export function resolveAvatarRedirectUrl(avatarSource: string, avatarInfo: string): string | null {
+  if (avatarSource === "qq") {
+    const qq = avatarInfo.trim();
+    if (!/^\d{5,11}$/.test(qq)) return null;
+    return `https://q1.qlogo.cn/g?b=qq&nk=${qq}&src_uin=www.jlwz.cn&s=0`;
+  }
+  try {
+    const url = new URL(avatarInfo);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -58,6 +58,26 @@ export class SettingItem {
   }
 }
 
+/**
+ * 从不可信来源（storage 旧数据回填 / 配置文件导入）提取合法设置：
+ * 只接受已知键且类型正确的字段，其余一律落回默认值，
+ * 防止错误类型的值或垃圾键被持久化。
+ */
+export function sanitizeSettings(raw: unknown): SettingItem {
+  const result = new SettingItem();
+  if (raw == null || typeof raw !== "object") return result;
+  const defaults = new SettingItem();
+  const source = raw as Record<string, unknown>;
+  const target = result as unknown as Record<string, unknown>;
+  for (const key of Object.keys(defaults)) {
+    const value = source[key];
+    if (typeof value === typeof (defaults as unknown as Record<string, unknown>)[key]) {
+      target[key] = value;
+    }
+  }
+  return result;
+}
+
 export interface CourseData {
   attribute: string;
   credit: number;

--- a/src/features/course-evaluation/index.ts
+++ b/src/features/course-evaluation/index.ts
@@ -14,8 +14,8 @@ function injectBtnStyle() {
             text-align: center !important;
             text-decoration: none !important;
             letter-spacing: 0.04em !important;
-            background: var(--scu-accent-fill, var(--scu-accent)) !important;
-            border: 1px solid var(--scu-accent-fill, var(--scu-accent)) !important;
+            background: var(--scu-accent-fill, var(--scu-accent, #9e1b32)) !important;
+            border: 1px solid var(--scu-accent-fill, var(--scu-accent, #9e1b32)) !important;
             border-radius: 2px !important;
             cursor: pointer !important;
             transition: all .12s ease !important;

--- a/src/features/course-filter/index.ts
+++ b/src/features/course-filter/index.ts
@@ -922,13 +922,14 @@ export function initCourseFilter(): void {
   }
 
   // 监听页面，若有课程表则注入面板
-  function waitForTableAndInject(): void {
+  function waitForTableAndInject(attempt: number = 0): void {
     const tbody: HTMLElement | null = document.getElementById('xirxkxkbody') || document.querySelector('tbody');
     if (tbody) {
       createPanel();
       watchTableAndRefilter(tbody);
-    } else {
-      setTimeout(waitForTableAndInject, 800);
+    } else if (attempt < 30) {
+      // 与 menu / course-table 一致的重试上限，避免在没有课程表的 frame 里永久轮询
+      setTimeout(() => waitForTableAndInject(attempt + 1), 800);
     }
   }
 

--- a/src/features/course-table/ics.ts
+++ b/src/features/course-table/ics.ts
@@ -34,7 +34,8 @@ const TIME_TABLE_HUAXI: Record<number, [string, string]> = {
 
 // ── 课表 API 与 planCode 解析 ───────────────────────────────────
 
-export const COURSE_SCHEDULE_API = 'http://zhjw.scu.edu.cn/student/courseSelect/thisSemesterCurriculum/ajaxStudentSchedule/callback';
+// 相对路径：跟随页面协议，避免 https 化后 mixed-content 失败
+export const COURSE_SCHEDULE_API = '/student/courseSelect/thisSemesterCurriculum/ajaxStudentSchedule/callback';
 
 export function parsePlanCode(): { planCode: string | null; isCurrentSemester: boolean } {
     if (!window.location.href.includes('calendarSemesterCurriculum')) {
@@ -284,22 +285,22 @@ function showFirstMondayModal(currentFirstMonday: Date, prefillDate: Date | null
         const pd = String(prefill.getDate()).padStart(2, '0');
         const prefillDateStr = `${py}-${pm}-${pd}`;
         overlay.innerHTML = `
-            <div style="background:#fff;border-radius:8px;padding:24px;min-width:380px;box-shadow:0 4px 12px rgba(0,0,0,0.15);">
+            <div style="background:var(--scu-surface,#fffdf8);color:var(--scu-ink,#1d1c1a);border-radius:8px;padding:24px;min-width:380px;box-shadow:0 4px 12px rgba(0,0,0,0.15);">
                 <h5 style="margin:0 0 16px;font-size:16px;">非当前学期，请选择第一周周一日期</h5>
                 <div style="margin-bottom:12px;">
                     <label style="display:flex;align-items:center;cursor:pointer;padding:8px 0;">
                         <input type="radio" name="firstMonday" value="manual" checked style="margin-right:8px;">
                         手动选择第一周周一
                     </label>
-                    <input type="date" id="scu-plus-manual-date" value="${prefillDateStr}" style="margin-left:24px;margin-top:4px;margin-bottom:4px;padding:4px 8px;border:1px solid #ccc;border-radius:4px;">
+                    <input type="date" id="scu-plus-manual-date" value="${prefillDateStr}" style="margin-left:24px;margin-top:4px;margin-bottom:4px;padding:4px 8px;border:1px solid var(--scu-line,#e4e0d4);border-radius:4px;background:var(--scu-paper,#f4f2ec);color:inherit;">
                     <label style="display:flex;align-items:center;cursor:pointer;padding:8px 0;">
                         <input type="radio" name="firstMonday" value="default" style="margin-right:8px;">
                         使用当前学期第一周周一 (${currentDateStr})
                     </label>
                 </div>
                 <div style="text-align:right;margin-top:16px;">
-                    <button id="scu-plus-modal-cancel" style="padding:6px 16px;margin-right:8px;border:1px solid #ccc;border-radius:4px;background:#fff;cursor:pointer;">取消</button>
-                    <button id="scu-plus-modal-confirm" style="padding:6px 16px;border:none;border-radius:4px;background:#428bca;color:#fff;cursor:pointer;">确定</button>
+                    <button id="scu-plus-modal-cancel" style="padding:6px 16px;margin-right:8px;border:1px solid var(--scu-line,#e4e0d4);border-radius:4px;background:var(--scu-surface,#fffdf8);color:inherit;cursor:pointer;">取消</button>
+                    <button id="scu-plus-modal-confirm" style="padding:6px 16px;border:none;border-radius:4px;background:var(--scu-accent-fill,var(--scu-accent,#9e1b32));color:#fff;cursor:pointer;">确定</button>
                 </div>
             </div>
         `;

--- a/src/features/ocr/captcha-autofill.ts
+++ b/src/features/ocr/captcha-autofill.ts
@@ -1,0 +1,127 @@
+/**
+ * 验证码自动识别的通用集成层。
+ *
+ * id.scu 与 zhjw 两个登录页查找验证码图片/输入框的方式不同，
+ * 但"识别 → 填写 → 刷新重试"的状态机完全一致，收敛在这里避免两份拷贝各自演化。
+ * 各登录页通过 CaptchaAutoFillOptions 注入差异点：定位、点击响应、识别函数。
+ */
+export interface CaptchaTarget {
+  img: HTMLImageElement;
+  input: HTMLInputElement;
+}
+
+export interface CaptchaAutoFillOptions {
+  /** 识别验证码图片，返回待填入文本（置信度不足时返回空串或非 4 位串） */
+  recognize: (img: HTMLImageElement) => Promise<string>;
+  /** 后台预加载识别模型，消除首次识别的加载延迟 */
+  warmup?: () => void;
+  /** 定位当前可用的验证码图片与输入框（需通过可见性校验）；无目标时返回 null */
+  locate: () => CaptchaTarget | null;
+  /**
+   * 捕获阶段点击监听：返回调度延迟毫秒数表示命中（如点击验证码图刷新、切换登录页签），
+   * 返回 null 表示不处理。
+   */
+  onClickCapture?: (target: Element) => number | null;
+  /** 初始调度延迟（ms），默认 120 */
+  initialDelay?: number;
+}
+
+export function createCaptchaAutoFill(options: CaptchaAutoFillOptions): void {
+  options.warmup?.();
+
+  let running = false;
+  let timer: number | null = null;
+  let lastCaptchaSrc = "";
+  let lastRecognizedSrc = "";
+  let retryCount = 0;
+
+  const scheduleRun = (delay = 120) => {
+    if (timer) {
+      window.clearTimeout(timer);
+    }
+    timer = window.setTimeout(() => {
+      void runOnce();
+    }, delay);
+  };
+
+  const bindCaptchaLoadListener = (img: HTMLImageElement) => {
+    const marker = "__scuOcrLoadBound";
+    if ((img as any)[marker]) return;
+    (img as any)[marker] = true;
+    img.addEventListener("load", () => scheduleRun(60));
+  };
+
+  const runOnce = async (): Promise<void> => {
+    if (running) return;
+    running = true;
+    try {
+      const target = options.locate();
+      if (!target) return;
+      const { img, input } = target;
+      bindCaptchaLoadListener(img);
+
+      if (!img.complete || !(img.naturalWidth || img.width) || !(img.naturalHeight || img.height)) {
+        return;
+      }
+
+      const src = img.currentSrc || img.src || "";
+      if (src !== lastCaptchaSrc) {
+        // 验证码已刷新：若输入框里是上次自动填入的结果，先清空再重新识别
+        if (lastRecognizedSrc && input.value.trim().length === 4) {
+          input.value = "";
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          input.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+        lastCaptchaSrc = src;
+        lastRecognizedSrc = "";
+        retryCount = 0;
+      }
+      // 输入框已有内容且并非本插件填入（用户手动输入）→ 不打扰
+      if (input.value.trim().length > 0 && !lastRecognizedSrc) return;
+      // 当前验证码已识别且结果仍在输入框 → 跳过
+      if (src === lastRecognizedSrc && input.value.trim().length === 4) return;
+
+      const resultRaw = await options.recognize(img);
+      const result = String(resultRaw || "").replace(/\s+/g, "");
+
+      if (result.length !== 4) {
+        // 识别置信度过低：稍作延迟再换一张，给新验证码的加载留出时间，
+        // 避免在新图就位前把重试次数烧在旧图上（本地 OCR 几乎是瞬时返回）
+        if (retryCount < 3) {
+          retryCount++;
+          window.setTimeout(() => img.click(), 350);
+        }
+        return;
+      }
+
+      retryCount = 0;
+      input.value = result;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      lastRecognizedSrc = src;
+    } catch (e) {
+      // 偶发失败（如图片未加载完成），保持静默等待下次触发。
+    } finally {
+      running = false;
+    }
+  };
+
+  document.addEventListener("click", (e) => {
+    const target = e.target as Element | null;
+    if (!target) return;
+    const delay = options.onClickCapture?.(target);
+    if (delay != null) scheduleRun(delay);
+  }, true);
+
+  try {
+    const mo = new MutationObserver(() => scheduleRun(120));
+    mo.observe(document.body || document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["class", "style", "src"]
+    });
+  } catch (e) {}
+
+  scheduleRun(options.initialDelay ?? 120);
+}

--- a/src/features/ocr/id-captcha.ts
+++ b/src/features/ocr/id-captcha.ts
@@ -1,18 +1,10 @@
 import { ocrLocal, warmupLocalOcr } from "~features/ocr/local-ocr";
+import { createCaptchaAutoFill } from "~features/ocr/captcha-autofill";
 import { getSetting } from "~script/config";
 
 export async function initIdCaptchaOcr(): Promise<void> {
   const savedSettings = await getSetting();
   if (!savedSettings.ocrSwitch) return;
-
-  // 后台预加载本地模型，消除首次识别的加载延迟
-  warmupLocalOcr();
-
-  let running = false;
-  let timer: number | null = null;
-  let lastCaptchaSrc = "";
-  let lastRecognizedSrc = "";
-  let retryCount = 0;
 
   // 登录页随浏览器语言切换中/英文，文案匹配必须双语覆盖。
   // 英文文案来自 id.scu.edu.cn 的 en-US 语言包：
@@ -79,107 +71,32 @@ export async function initIdCaptchaOcr(): Promise<void> {
     return form.querySelector<HTMLImageElement>("img");
   };
 
-  const scheduleRun = (delay = 120) => {
-    if (timer) {
-      window.clearTimeout(timer);
-    }
-    timer = window.setTimeout(() => {
-      void runOcrForCurrentTab();
-    }, delay);
-  };
-
-  const bindCaptchaLoadListener = (img: HTMLImageElement) => {
-    const marker = "__scuOcrLoadBound";
-    if ((img as any)[marker]) return;
-    (img as any)[marker] = true;
-    img.addEventListener("load", () => scheduleRun(60));
-  };
-
-  const runOcrForCurrentTab = async (): Promise<void> => {
-    if (running) return;
-    running = true;
-    try {
+  createCaptchaAutoFill({
+    recognize: ocrLocal,
+    warmup: warmupLocalOcr,
+    locate: () => {
+      // 只处理账号登录 / 短信登录页签，其他页签没有验证码
       const activeTab = getActiveTabText();
-      if (!(ACCOUNT_TAB_RE.test(activeTab) || SMS_TAB_RE.test(activeTab))) return;
+      if (!(ACCOUNT_TAB_RE.test(activeTab) || SMS_TAB_RE.test(activeTab))) return null;
 
       const form = getCurrentLoginForm();
-      if (!form) return;
+      if (!form) return null;
 
       const input = getCaptchaInput(form);
-      if (!input || !isVisible(input)) return;
+      if (!input || !isVisible(input)) return null;
 
       const img = getCaptchaImage(form, input);
-      if (!img || !isVisible(img)) return;
+      if (!img || !isVisible(img)) return null;
 
-      bindCaptchaLoadListener(img);
-
-      if (!img.complete || !(img.naturalWidth || img.width) || !(img.naturalHeight || img.height)) {
-        return;
-      }
-
-      const src = img.currentSrc || img.src || "";
-      if (src !== lastCaptchaSrc) {
-        // 验证码已刷新：若输入框里是上次自动填入的结果，先清空再重新识别
-        if (lastRecognizedSrc && input.value.trim().length === 4) {
-          input.value = "";
-          input.dispatchEvent(new Event("input", { bubbles: true }));
-          input.dispatchEvent(new Event("change", { bubbles: true }));
-        }
-        lastCaptchaSrc = src;
-        lastRecognizedSrc = "";
-        retryCount = 0;
-      }
-      // 输入框已有内容且并非本插件填入（用户手动输入）→ 不打扰
-      if (input.value.trim().length > 0 && !lastRecognizedSrc) return;
-      // 当前验证码已识别且结果仍在输入框 → 跳过
-      if (src === lastRecognizedSrc && input.value.trim().length === 4) return;
-
-      const resultRaw = await ocrLocal(img);
-      const result = String(resultRaw || "").replace(/\s+/g, "");
-
-      if (result.length !== 4) {
-        // 识别置信度过低：稍作延迟再换一张，给新验证码的加载留出时间，
-        // 避免在新图就位前把重试次数烧在旧图上（本地 OCR 几乎是瞬时返回）
-        if (retryCount < 3) {
-          retryCount++;
-          window.setTimeout(() => img.click(), 350);
-        }
-        return;
-      }
-
-      retryCount = 0;
-      input.value = result;
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-      input.dispatchEvent(new Event("change", { bubbles: true }));
-      lastRecognizedSrc = src;
-    } catch (e) {
-      // 本地 OCR 偶发失败（如图片未加载完成），保持静默等待下次触发。
-    } finally {
-      running = false;
-    }
-  };
-
-  document.addEventListener("click", (e) => {
-    const target = e.target as Element | null;
-    if (!target) return;
-    if (target.closest(".login-tab .login-tab-item")) {
-      scheduleRun(160);
-      return;
-    }
-    if (target instanceof HTMLImageElement && target.closest(".captcha-box")) {
-      scheduleRun(120);
-    }
-  }, true);
-
-  try {
-    const mo = new MutationObserver(() => scheduleRun(120));
-    mo.observe(document.body || document.documentElement, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      attributeFilter: ["class", "style", "src"]
-    });
-  } catch (e) {}
-
-  scheduleRun(50);
+      return { img, input };
+    },
+    onClickCapture: (target) => {
+      // 切换登录页签后表单整体更换，需要重新定位
+      if (target.closest(".login-tab .login-tab-item")) return 160;
+      // 点击验证码图（刷新验证码）后立即重新识别
+      if (target instanceof HTMLImageElement && target.closest(".captcha-box")) return 120;
+      return null;
+    },
+    initialDelay: 50
+  });
 }

--- a/src/features/ocr/local-ocr.ts
+++ b/src/features/ocr/local-ocr.ts
@@ -14,11 +14,11 @@ import {
   CHAR_W,
   FEAT_DIM,
   FEAT_DIM_WITH_AR,
-  CentroidWeights,
   parseCentroidJson,
   classifyChar,
   normalizeAspectRatio
 } from "~features/ocr/model"
+import type { CentroidWeights } from "~features/ocr/model"
 
 // ---------------------------------------------------------------------------
 // 预处理常量（与训练一致）

--- a/src/features/ocr/zhjw-captcha-ocr.ts
+++ b/src/features/ocr/zhjw-captcha-ocr.ts
@@ -2,21 +2,21 @@
  * zhjw 验证码 OCR 的浏览器侧封装：
  *   1. 通过外部 OCR 包识别验证码（模型与 CNN 推理已移至独立仓库）
  *   2. 预处理（去黑线、灰度反色、缩放）与推理由外部包完成
- *   3. 本文件只负责 zhjw 登录页的 DOM 集成：查找验证码图片/输入框、自动识别并填写
+ *   3. 本文件只负责 zhjw 登录页的 DOM 集成：查找验证码图片/输入框，
+ *      识别/填写/重试的状态机在 `captcha-autofill.ts`
  *
  * 若外部 OCR 包尚未接入（见 `docs/ocr-package-integration.md`），
  * 识别自动降级为空串，不影响登录页其余功能。
  */
 import { getZhjwCaptchaRecognizer, warmupZhjwOcr } from "~features/ocr/zhjw-ocr-adapter"
+import { createCaptchaAutoFill } from "~features/ocr/captcha-autofill"
 import { getSetting } from "~script/config"
 
-export { warmupZhjwOcr }
-
 /**
- * 识别 zhjw 验证码图片，返回 4 位字符。
+ * 识别 zhjw 验证码图片。
  * 未接入外部 OCR 包、或置信度不足、或图片不可用时返回空串。
  */
-export async function ocrZhjw(imageElement: HTMLImageElement): Promise<string> {
+async function ocrZhjw(imageElement: HTMLImageElement): Promise<string> {
   const recognizer = getZhjwCaptchaRecognizer();
   if (!recognizer) {
     console.warn("[SCU+] zhjw 验证码识别未接入（外部 OCR 包未安装），跳过识别");
@@ -30,9 +30,63 @@ export async function ocrZhjw(imageElement: HTMLImageElement): Promise<string> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// 内容脚本集成
-// ---------------------------------------------------------------------------
+const isVisible = (el: Element | null): el is HTMLElement => {
+  if (!(el instanceof HTMLElement)) return false;
+  const style = window.getComputedStyle(el);
+  return style.display !== "none" && style.visibility !== "hidden" && el.offsetParent !== null;
+};
+
+/** 查找验证码图片 */
+const getCaptchaImage = (): HTMLImageElement | null => {
+  const selectors = [
+    "img#captchaImg",
+    "img.captcha",
+    "img[src*='captcha']",
+    "img[src*='verifyCode']",
+    "img[src*='imgcode']",
+    "img[src*='Captcha']",
+  ];
+  for (const sel of selectors) {
+    const img = document.querySelector<HTMLImageElement>(sel);
+    if (img && isVisible(img)) return img;
+  }
+  // 兜底：查找登录表单内的图片
+  const form = document.querySelector("form");
+  if (form) {
+    const img = form.querySelector<HTMLImageElement>("img");
+    if (img && isVisible(img)) return img;
+  }
+  return null;
+};
+
+/** 查找验证码输入框 */
+const getCaptchaInput = (): HTMLInputElement | null => {
+  const selectors = [
+    "input#captcha",
+    "input[name='captcha']",
+    "input[name='validateCode']",
+    "input[name='verifyCode']",
+    "input[placeholder*='验证码']",
+    "input[placeholder*='captcha' i]",
+  ];
+  for (const sel of selectors) {
+    const input = document.querySelector<HTMLInputElement>(sel);
+    if (input && isVisible(input)) return input;
+  }
+  // 兜底：查找登录表单内较短的文本输入框（验证码输入框通常较短）
+  const form = document.querySelector("form");
+  if (form) {
+    const inputs = Array.from(form.querySelectorAll<HTMLInputElement>("input[type='text']"));
+    const visible = inputs.filter(isVisible);
+    // 排除用户名输入框（通常 name/placeholder 包含 user/账号/学号）
+    const captchaLike = visible.filter((i) => {
+      const name = (i.name + " " + i.placeholder + " " + i.id).toLowerCase();
+      return !name.includes("user") && !name.includes("账号") && !name.includes("学号") && !name.includes("username");
+    });
+    if (captchaLike.length > 0) return captchaLike[captchaLike.length - 1];
+  }
+  return null;
+};
 
 /**
  * 初始化 zhjw 登录页验证码自动识别。
@@ -42,159 +96,26 @@ export async function initZhjwCaptchaOcr(): Promise<void> {
   const savedSettings = await getSetting();
   if (!savedSettings.ocrSwitch) return;
 
-  // 后台预加载模型
-  warmupZhjwOcr();
-
-  let running = false;
-  let timer: number | null = null;
-  let lastCaptchaSrc = "";
-  let lastRecognizedSrc = "";
-  let retryCount = 0;
-
-  const isVisible = (el: Element | null): el is HTMLElement => {
-    if (!(el instanceof HTMLElement)) return false;
-    const style = window.getComputedStyle(el);
-    return style.display !== "none" && style.visibility !== "hidden" && el.offsetParent !== null;
-  };
-
-  /** 查找验证码图片 */
-  const getCaptchaImage = (): HTMLImageElement | null => {
-    const selectors = [
-      "img#captchaImg",
-      "img.captcha",
-      "img[src*='captcha']",
-      "img[src*='verifyCode']",
-      "img[src*='imgcode']",
-      "img[src*='Captcha']",
-    ];
-    for (const sel of selectors) {
-      const img = document.querySelector<HTMLImageElement>(sel);
-      if (img && isVisible(img)) return img;
-    }
-    // 兜底：查找登录表单内的图片
-    const form = document.querySelector("form");
-    if (form) {
-      const img = form.querySelector<HTMLImageElement>("img");
-      if (img && isVisible(img)) return img;
-    }
-    return null;
-  };
-
-  /** 查找验证码输入框 */
-  const getCaptchaInput = (): HTMLInputElement | null => {
-    const selectors = [
-      "input#captcha",
-      "input[name='captcha']",
-      "input[name='validateCode']",
-      "input[name='verifyCode']",
-      "input[placeholder*='验证码']",
-      "input[placeholder*='captcha' i]",
-    ];
-    for (const sel of selectors) {
-      const input = document.querySelector<HTMLInputElement>(sel);
-      if (input && isVisible(input)) return input;
-    }
-    // 兜底：查找登录表单内较短的文本输入框（验证码输入框通常较短）
-    const form = document.querySelector("form");
-    if (form) {
-      const inputs = Array.from(form.querySelectorAll<HTMLInputElement>("input[type='text']"));
-      const visible = inputs.filter(isVisible);
-      // 排除用户名输入框（通常 name/placeholder 包含 user/账号/学号）
-      const captchaLike = visible.filter((i) => {
-        const name = (i.name + " " + i.placeholder + " " + i.id).toLowerCase();
-        return !name.includes("user") && !name.includes("账号") && !name.includes("学号") && !name.includes("username");
-      });
-      if (captchaLike.length > 0) return captchaLike[captchaLike.length - 1];
-    }
-    return null;
-  };
-
-  const scheduleRun = (delay = 120) => {
-    if (timer) window.clearTimeout(timer);
-    timer = window.setTimeout(() => {
-      void runOcr();
-    }, delay);
-  };
-
-  const bindCaptchaLoadListener = (img: HTMLImageElement) => {
-    const marker = "__scuZhjwOcrLoadBound";
-    if ((img as any)[marker]) return;
-    (img as any)[marker] = true;
-    img.addEventListener("load", () => scheduleRun(60));
-  };
-
-  const runOcr = async (): Promise<void> => {
-    if (running) return;
-    running = true;
-    try {
+  createCaptchaAutoFill({
+    recognize: ocrZhjw,
+    warmup: warmupZhjwOcr,
+    locate: () => {
       const img = getCaptchaImage();
-      if (!img) return;
-      bindCaptchaLoadListener(img);
-
-      if (!img.complete || !(img.naturalWidth || img.width) || !(img.naturalHeight || img.height)) {
-        return;
-      }
-
+      if (!img) return null;
       const input = getCaptchaInput();
-      if (!input || !isVisible(input)) return;
-
-      const src = img.currentSrc || img.src || "";
-      if (src !== lastCaptchaSrc) {
-        if (lastRecognizedSrc && input.value.trim().length === 4) {
-          input.value = "";
-          input.dispatchEvent(new Event("input", { bubbles: true }));
-          input.dispatchEvent(new Event("change", { bubbles: true }));
+      if (!input) return null;
+      return { img, input };
+    },
+    onClickCapture: (target) => {
+      // 点击验证码图（刷新验证码）后立即重新识别
+      if (target instanceof HTMLImageElement) {
+        const src = (target.src || "").toLowerCase();
+        if (src.includes("captcha") || src.includes("verifycode") || src.includes("imgcode")) {
+          return 120;
         }
-        lastCaptchaSrc = src;
-        lastRecognizedSrc = "";
-        retryCount = 0;
       }
-      if (input.value.trim().length > 0 && !lastRecognizedSrc) return;
-      if (src === lastRecognizedSrc && input.value.trim().length === 4) return;
-
-      const resultRaw = await ocrZhjw(img);
-      const result = String(resultRaw || "").replace(/\s+/g, "");
-
-      if (result.length !== 4) {
-        if (retryCount < 3) {
-          retryCount++;
-          window.setTimeout(() => img.click(), 350);
-        }
-        return;
-      }
-
-      retryCount = 0;
-      input.value = result;
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-      input.dispatchEvent(new Event("change", { bubbles: true }));
-      lastRecognizedSrc = src;
-    } catch (e) {
-      // 偶发失败，静默等待下次触发
-    } finally {
-      running = false;
-    }
-  };
-
-  document.addEventListener("click", (e) => {
-    const target = e.target as Element | null;
-    if (!target) return;
-    if (target instanceof HTMLImageElement) {
-      const src = (target.src || "").toLowerCase();
-      if (src.includes("captcha") || src.includes("verifycode") || src.includes("imgcode")) {
-        scheduleRun(120);
-      }
-    }
-  }, true);
-
-  try {
-    const mo = new MutationObserver(() => scheduleRun(120));
-    mo.observe(document.body || document.documentElement, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      attributeFilter: ["class", "style", "src"]
-    });
-  } catch (e) {}
-
-  scheduleRun(200);
+      return null;
+    },
+    initialDelay: 200
+  });
 }

--- a/src/features/schedule/index.ts
+++ b/src/features/schedule/index.ts
@@ -44,25 +44,35 @@ export async function injectSchoolSchedule(): Promise<void> {
     }
   }
 
-  let injectHtml = "";
-  for (const schedule of scheduleList) {
-    injectHtml += `<li><a href="${schedule.link}" target="_blank" style="color:var(--scu-ink-soft,#333);padding:8px 20px;">${schedule.name}</a></li>`;
-  }
-
-  const fullHtml = `
-    <li class="dropdown">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-        <i class="icon-calendar"></i>
-        <span>校历查看<span style="color:var(--scu-accent,#9e1b32)">✦</span></span>
-      </a>
-      <ul class="dropdown-menu" style="min-width:200px;border-radius:4px;box-shadow:0 2px 8px rgba(0,0,0,0.1);">
-        ${injectHtml}
-      </ul>
-    </li>
+  // 远程页面抓来的 name/link 不可信，全部用 DOM API / textContent 构造，避免 HTML 注入
+  const dropdown = document.createElement("li");
+  dropdown.className = "dropdown";
+  dropdown.innerHTML = `
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+      <i class="icon-calendar"></i>
+      <span>校历查看<span style="color:var(--scu-accent,#9e1b32)">✦</span></span>
+    </a>
   `;
+  const menu = document.createElement("ul");
+  menu.className = "dropdown-menu";
+  menu.style.cssText = "min-width:200px;border-radius:4px;box-shadow:0 2px 8px rgba(0,0,0,0.1);";
+  for (const schedule of scheduleList) {
+    const url = new URL(schedule.link);
+    if (url.protocol !== "https:" && url.protocol !== "http:") continue;
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = url.href;
+    a.target = "_blank";
+    a.style.color = "var(--scu-ink-soft,#333)";
+    a.style.padding = "8px 20px";
+    a.textContent = schedule.name;
+    li.appendChild(a);
+    menu.appendChild(li);
+  }
+  dropdown.appendChild(menu);
 
   const injectPosition = document.querySelector("#navbar-container > div.navbar-buttons.navbar-header.pull-right > ul > li.green.cdsj");
   if (injectPosition) {
-    injectPosition.outerHTML = fullHtml;
+    injectPosition.replaceWith(dropdown);
   }
 }

--- a/src/features/schedule/index.ts
+++ b/src/features/schedule/index.ts
@@ -35,13 +35,16 @@ export async function injectSchoolSchedule(): Promise<void> {
   for (const li of lis) {
     const a = li.querySelector("a");
     const href = a?.getAttribute("href");
-    if (a && href) {
-      scheduleList.push({
-        name: a.innerText,
-        // href 可能是绝对地址或相对路径，用 URL 正确拼接
-        link: new URL(href, "https://jwc.scu.edu.cn/").href
-      });
+    if (!a || !href) continue;
+    let link: string;
+    try {
+      // href 可能是绝对地址或相对路径，用 URL 正确拼接；
+      // 远程内容可能带非法字符（未转义空格/% 等），解析失败的单条直接跳过
+      link = new URL(href, "https://jwc.scu.edu.cn/").href;
+    } catch {
+      continue;
     }
+    scheduleList.push({ name: a.innerText, link });
   }
 
   // 远程页面抓来的 name/link 不可信，全部用 DOM API / textContent 构造，避免 HTML 注入
@@ -57,7 +60,12 @@ export async function injectSchoolSchedule(): Promise<void> {
   menu.className = "dropdown-menu";
   menu.style.cssText = "min-width:200px;border-radius:4px;box-shadow:0 2px 8px rgba(0,0,0,0.1);";
   for (const schedule of scheduleList) {
-    const url = new URL(schedule.link);
+    let url: URL;
+    try {
+      url = new URL(schedule.link);
+    } catch {
+      continue;
+    }
     if (url.protocol !== "https:" && url.protocol !== "http:") continue;
     const li = document.createElement("li");
     const a = document.createElement("a");

--- a/src/script/config.ts
+++ b/src/script/config.ts
@@ -1,5 +1,5 @@
 import { Storage } from "@plasmohq/storage"
-import { SettingItem } from "../common/types"
+import { sanitizeSettings, SettingItem } from "../common/types"
 
 export {
  getSetting,
@@ -13,14 +13,15 @@ async function getSetting(): Promise<SettingItem> {
     if(cache!=null){
      return cache;
     }
-    let config:SettingItem=await storage.get("setting");
-    if(config==null){
+    const raw = await storage.get("setting");
+    let config:SettingItem;
+    if(raw==null){
       config=new SettingItem();
-      storage.set("setting",config);
+      await storage.set("setting",config);
     }else{
       // 旧版本存储的配置可能缺少后续新增的字段，用默认值回填，
       // 避免默认 true 的开关（如 failSwitch）因缺失变成 undefined 而被静默禁用
-      config=Object.assign(new SettingItem(),config);
+      config=sanitizeSettings(raw);
     }
     cache=config;
     return config;
@@ -29,3 +30,11 @@ function saveSetting(setting: SettingItem) {
   cache=setting;
   storage.set("setting", setting)
 }
+// 其他 context（popup / 设置页 / 其他标签页）写入时同步刷新本 context 的缓存，
+// 避免长生命周期页面二次 getSetting 时拿陈旧值整体写回、覆盖别人的修改
+storage.watch({
+  setting: (change) => {
+    if (change?.newValue == null) return
+    cache = sanitizeSettings(change.newValue)
+  }
+})

--- a/src/setting.tsx
+++ b/src/setting.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from "react"
 import { getSetting, saveSetting } from "~script/config";
-import { SettingItem } from "~common/types";
+import { sanitizeSettings, SettingItem } from "~common/types";
+import { resolveAvatarRedirectUrl } from "~common/avatar";
 import { message, notification, confirm } from "~script/notice";
 import React from "react";
 import { Actions } from "~constants/actions";
@@ -358,15 +359,12 @@ function saveSettingWithUpdates(data: SettingItem) {
   UpdateRedirect(data);
 }
 function UpdateRedirect(newConfig: SettingItem) {
-  if (newConfig.avatarSwitch) {
-    if (newConfig.avatarSource === 'qq') {
-      chrome.runtime.sendMessage({ action: Actions.UPDATE_AVATAR, url: `https://q1.qlogo.cn/g?b=qq&nk=${newConfig.avatarInfo}&src_uin=www.jlwz.cn&s=0` });
-    }
-    else {
-      chrome.runtime.sendMessage({ action: Actions.UPDATE_AVATAR, url: newConfig.avatarInfo });
-    }
+  const url = resolveAvatarRedirectUrl(newConfig.avatarSource, newConfig.avatarInfo);
+  if (newConfig.avatarSwitch && url) {
+    chrome.runtime.sendMessage({ action: Actions.UPDATE_AVATAR, url });
   }
   else {
+    // 开关关闭、或 avatarInfo 非法时，一并清掉可能残留的重定向规则
     chrome.runtime.sendMessage({ action: Actions.REMOVE_AVATAR_REDIRECTION })
   }
 }
@@ -521,7 +519,8 @@ function DataSettingFragment({ isDirty, setIsDirty, setAccent, setDarkMode }: { 
                 if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
                   throw new Error('not a settings object');
                 }
-                const jsonData = { ...setting, ...parsed };
+                // 只接受已知键且类型正确的字段，防止导入文件注入垃圾数据
+                const jsonData = sanitizeSettings({ ...setting, ...parsed });
                 saveSettingWithUpdates(jsonData);
                 setSetting(jsonData);
                 setAccent(normalizeAccent(jsonData.beautifyColor));


### PR DESCRIPTION
## 说明

本轮对项目做了一次完整代码审查，本 PR 落地其中确认要修的问题。共 9 个 commit，按逻辑分组，每个 commit 可独立构建与回滚。

## 改动内容

### 真 bug 修复
- **CI 发布错位**（`c1f7ea4`）：`workflow_dispatch` 手动发布时 checkout 的是触发分支而非指定 tag，会以 main 代码冒充 tag 版本发版。改用 `actions/checkout@v4` 检出 `inputs.tag`；顺带补最小权限声明、Node 钉到 22.13、清理恒真条件
- **评教按钮不可见**（`96d849a`）：`var(--scu-accent-fill, var(--scu-accent))` 无 hex 兜底，美化关闭时按钮透明+白字
- **ICS 导出弹窗深色模式白底**（`bd1f111`）：硬编码白底蓝按钮改 `var(--scu-*, fallback)`；课表 API 顺带改相对路径，避免 https 化后 mixed-content

### 健壮性 / 安全
- **getSetting 缓存**（`529b4d1`）：通过 `storage.watch` 跨 context 失效，消除长生命周期页面拿陈旧缓存整体写回的问题；新增 `sanitizeSettings`，storage 回填与配置文件导入共用键白名单+类型校验
- **background 加固**（`68d63a9`）：消息 switch 分发+未知 action 告警；REQUEST 代理显式域名白名单（scu.edu.cn / api.github.com / q1.qlogo.cn）；头像重定向接受 http(s) 并做 URL 校验；DNR 规则循环构造；`onStartup`/`onInstalled` 按当前设置对账动态规则
- **校历注入**（`678d397`）：远程抓取内容不再拼 innerHTML，改 DOM API 构造并过滤非 http(s) 链接
- **选课筛选轮询上限**（`43b7b47`）：无课表 frame 不再永久轮询（与 menu/course-table 对齐为 30 次）

### 重构
- **OCR 状态机合并**（`611f2a0`）：id/zhjw 两个登录页完全相同的"识别→填写→刷新重试"状态机抽取为 `captcha-autofill.ts`，各页面只保留定位逻辑，净减约 100 行重复

### 工程化（`9a9c9d1`）
- 补 `engines.node`（与 AMO 脚本/CI 对齐）、`@types/react` 对齐 18、plasmo 移入 devDependencies
- 新增 `pnpm typecheck` 脚本（已修复唯一的既有类型报错）

## 已验证

- `tsc --noEmit` 通过
- `pnpm build`（Chrome）与 `pnpm build --zip --target=firefox-mv3` 通过，产物 manifest 检查正常

## ⚠️ 待人工测试（无自动化测试，以下需在真实站点验证）

- [x] **设置链路**：弹窗切换深色模式 → 已打开的教务页主题即时变化；设置页修改并保存 → 刷新教务页后设置未回滚；导入正常配置文件成功、导入含垃圾键/错误类型字段的 JSON 被过滤；恢复默认
- [x] **头像重定向**：QQ 号和自定义（含 http 地址）都生效；输入明显非法的地址不生效且不报错；关闭开关恢复默认头像；**重启浏览器后规则仍在**（onStartup 对账新增路径）
- [x] **评教页**：美化关闭时按钮可见（深红底白字）、美化开启时正常；一键评教完整流程
- [ ] **选课筛选面板**：面板正常出现、筛选功能正常
- [ ] **课表页**：导出 ICS——非当前学期时弹窗出现，深色模式下配色正常；导出 JSON/图片正常（API 改相对路径的回归）
- [x] **校历**：教务导航栏校历下拉正常显示、各链接可点击
- [x] **id.scu 登录页 OCR**：账号登录/短信登录页签切换后自动识别仍工作；点验证码图刷新后重新识别；手动输入不被覆盖
- [x] **zhjw 登录页 OCR**：自动识别+填写正常；点图刷新后重新识别
- [ ] **CI**（下次发版时验证）：`workflow_dispatch` 手动填 tag 发布 → 确认 Release 挂在 tag 对应的 commit 上、产物可安装