### PR TITLE
feat: add Safari builds and macOS/TestFlight distribution links

### DIFF
--- a/.github/generate_release_notes.py
+++ b/.github/generate_release_notes.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
         "请下载 chrome-mv3-prod.zip 文件\n\n"
         "目前FireFox扩展正在测试中，稳定性未知，建议在测试环境中使用。\n\n"
         f"macOS Safari：[下载对应版本](https://github.com/Visio-Vanitas/scu-plus/releases/tag/{quote('v' + version, safe='')})，由独立分发仓库签名和公证。上游发布后需要等待构建完成；若对应版本尚未生成，请查看[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
+        "**不建议任何不了解 IPA 的同学下载或尝试安装。** iOS/iPadOS：上述分发页提供未签名 IPA，需自行重签主应用及 Safari 扩展后安装，仅供技术测试；原生断点调试请从源码构建。也可通过 [TestFlight](https://testflight.apple.com/join/VfB4puVJ) 邀测，安装取决于审核和当前测试状态。\n\n"
         + get_release_notes(version)
     )
     print(release_notes)

--- a/.github/generate_release_notes.py
+++ b/.github/generate_release_notes.py
@@ -50,9 +50,9 @@ if __name__ == "__main__":
     release_notes = (
         "请下载 chrome-mv3-prod.zip 文件\n\n"
         "目前FireFox扩展正在测试中，稳定性未知，建议在测试环境中使用。\n\n"
-        f"macOS Safari：[签名 DMG](https://github.com/Visio-Vanitas/scu-plus/releases/download/{quote('v' + version, safe='')}/scu-plus-safari-macos.dmg)，由独立分发仓库签名和公证。上游发布后需要等待构建完成；若对应版本尚未生成，请查看[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
-        "iOS/iPadOS：[通过 TestFlight 安装](https://testflight.apple.com/join/VfB4puVJ)，可安装版本以 Apple 审核和当前测试状态为准。\n\n"
-        f"开发者测试与调试：[未签名 IPA](https://github.com/Visio-Vanitas/scu-plus/releases/download/{quote('v' + version, safe='')}/scu-plus-safari-ios-unsigned.ipa)，需要自行重签主应用及 Safari 扩展。**不建议任何不了解 IPA 的同学下载或尝试安装。** 原生断点调试请从源码构建。\n\n"
+        f"macOS Safari：[dmg](https://github.com/Visio-Vanitas/scu-plus/releases/download/{quote('v' + version, safe='')}/scu-plus-safari-macos.dmg)。若对应版本尚未生成，请联系维护者检查[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
+        "iOS/iPadOS：[通过 TestFlight 安装](https://testflight.apple.com/join/VfB4puVJ)，可安装版本以 Apple 审核和当前测试状态为准，不保证同步更新。\n\n"
+        f"另提供：[未签名 IPA](https://github.com/Visio-Vanitas/scu-plus/releases/download/{quote('v' + version, safe='')}/scu-plus-safari-ios-unsigned.ipa)，需自行重签主应用及 Safari 扩展。不建议任何不了解 IPA 的同学下载或尝试安装，不接受相关错误报告。\n\n"
         + get_release_notes(version)
     )
     print(release_notes)

--- a/.github/generate_release_notes.py
+++ b/.github/generate_release_notes.py
@@ -50,9 +50,9 @@ if __name__ == "__main__":
     release_notes = (
         "请下载 chrome-mv3-prod.zip 文件\n\n"
         "目前FireFox扩展正在测试中，稳定性未知，建议在测试环境中使用。\n\n"
-        f"macOS Safari：[下载对应版本](https://github.com/Visio-Vanitas/scu-plus/releases/tag/{quote('v' + version, safe='')})，由独立分发仓库签名和公证。上游发布后需要等待构建完成；若对应版本尚未生成，请查看[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
+        f"macOS Safari：[签名 DMG](https://github.com/Visio-Vanitas/scu-plus/releases/download/{quote('v' + version, safe='')}/scu-plus-safari-macos.dmg)，由独立分发仓库签名和公证。上游发布后需要等待构建完成；若对应版本尚未生成，请查看[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
         "iOS/iPadOS：[通过 TestFlight 安装](https://testflight.apple.com/join/VfB4puVJ)，可安装版本以 Apple 审核和当前测试状态为准。\n\n"
-        "开发者测试与调试：上述分发页的附件另提供未签名 IPA，需要自行重签主应用及 Safari 扩展。**不建议任何不了解 IPA 的同学下载或尝试安装。** 原生断点调试请从源码构建。\n\n"
+        f"开发者测试与调试：[未签名 IPA](https://github.com/Visio-Vanitas/scu-plus/releases/download/{quote('v' + version, safe='')}/scu-plus-safari-ios-unsigned.ipa)，需要自行重签主应用及 Safari 扩展。**不建议任何不了解 IPA 的同学下载或尝试安装。** 原生断点调试请从源码构建。\n\n"
         + get_release_notes(version)
     )
     print(release_notes)

--- a/.github/generate_release_notes.py
+++ b/.github/generate_release_notes.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+from urllib.parse import quote
 
 
 def get_version() -> str:
@@ -49,6 +50,7 @@ if __name__ == "__main__":
     release_notes = (
         "请下载 chrome-mv3-prod.zip 文件\n\n"
         "目前FireFox扩展正在测试中，稳定性未知，建议在测试环境中使用。\n\n"
+        f"macOS Safari：[下载对应版本](https://github.com/Visio-Vanitas/scu-plus/releases/tag/{quote('v' + version, safe='')})，由独立分发仓库签名和公证。上游发布后需要等待构建完成；若对应版本尚未生成，请查看[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
         + get_release_notes(version)
     )
     print(release_notes)

--- a/.github/generate_release_notes.py
+++ b/.github/generate_release_notes.py
@@ -51,7 +51,8 @@ if __name__ == "__main__":
         "请下载 chrome-mv3-prod.zip 文件\n\n"
         "目前FireFox扩展正在测试中，稳定性未知，建议在测试环境中使用。\n\n"
         f"macOS Safari：[下载对应版本](https://github.com/Visio-Vanitas/scu-plus/releases/tag/{quote('v' + version, safe='')})，由独立分发仓库签名和公证。上游发布后需要等待构建完成；若对应版本尚未生成，请查看[构建状态](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。\n\n"
-        "**不建议任何不了解 IPA 的同学下载或尝试安装。** iOS/iPadOS：上述分发页提供未签名 IPA，需自行重签主应用及 Safari 扩展后安装，仅供技术测试；原生断点调试请从源码构建。也可通过 [TestFlight](https://testflight.apple.com/join/VfB4puVJ) 邀测，安装取决于审核和当前测试状态。\n\n"
+        "iOS/iPadOS：[通过 TestFlight 安装](https://testflight.apple.com/join/VfB4puVJ)，可安装版本以 Apple 审核和当前测试状态为准。\n\n"
+        "开发者测试与调试：上述分发页的附件另提供未签名 IPA，需要自行重签主应用及 Safari 扩展。**不建议任何不了解 IPA 的同学下载或尝试安装。** 原生断点调试请从源码构建。\n\n"
         + get_release_notes(version)
     )
     print(release_notes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 注意：本页的更新日志应当存放一些通俗显著的更新内容，而非技术更新或者内部优化，请勿搬运git log记录。
 
 
+## [Unreleased]
+
+### Added
+
+- 提供 macOS Safari 安装入口，发布说明链接到独立签名分发仓库的对应版本。
+
 ## [2.3.3] - 2026-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- 提供 Safari 安装入口，发布说明链接到独立分发仓库的对应版本：macOS 签名安装包、供自行重签测试的 iOS/iPadOS 未签名 IPA，以及 TestFlight 邀测入口。
+- 提供 Safari 安装入口，发布说明链接到独立分发仓库的对应版本：macOS 签名安装包和 iOS/iPadOS TestFlight 发布链接；另为开发者提供需自行重签的 IPA 测试产物。
 
 ## [2.3.3] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- 提供 macOS Safari 安装入口，发布说明链接到独立签名分发仓库的对应版本。
+- 提供 Safari 安装入口，发布说明链接到独立分发仓库的对应版本：macOS 签名安装包、供自行重签测试的 iOS/iPadOS 未签名 IPA，以及 TestFlight 邀测入口。
 
 ## [2.3.3] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@
 
 </div>
 
+## Safari（macOS）
+
+Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Visio-Vanitas/scu-plus/releases)提供，跟随本仓库发布的版本 tag 构建，使用 Developer ID 签名并经 Apple 公证。下载对应版本的 DMG，将 SCU Plus 拖到“应用程序”，再在 Safari 设置 → 扩展中启用并授予所需网站权限。iOS/iPadOS 暂不包含在此分发流程中。
+
+上游新版本发布后，Safari 安装包需要等待构建、公证完成；进度见[分发构建](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。本仓库不保存 Apple 签名凭据，也不需要配置跨仓库 Secret。
+
+开发者可使用 `pnpm build:safari` 生成未签名的 `build/safari-mv3-prod.zip`；该 ZIP 用于开发测试，不能替代上述 macOS 安装包。开发运行方式见 [Apple 官方说明](https://developer.apple.com/documentation/safariservices/running-your-safari-web-extension)。
+
 ## ✨ 核心功能
 
 ### 🛡️ 隐私与安全

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@
 
 Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Visio-Vanitas/scu-plus/releases)提供，跟随本仓库发布的版本 tag 构建，使用 Developer ID 签名并经 Apple 公证。下载对应版本的 DMG，将 SCU Plus 拖到“应用程序”，再在 Safari 设置 → 扩展中启用并授予所需网站权限。
 
-> **不建议任何不了解 IPA 的同学下载或尝试安装。** 普通测试者请使用下方 TestFlight 入口。
+iOS/iPadOS：[通过 TestFlight 安装](https://testflight.apple.com/join/VfB4puVJ)。安装后在 Safari 设置中启用 SCU Plus 并授予所需网站权限；可安装版本以 Apple 审核和当前测试状态为准。
 
-iOS/iPadOS：同一 Release 提供 `scu-plus-safari-ios-unsigned.ipa`，供有技术背景的同学自行重签后测试。它不能直接安装；必须使用自己的签名身份和匹配的描述文件同时重签主 App 与 Safari 扩展，再安装并在 Safari 设置中启用。该包是 Release 构建，原生断点调试需从源码使用 Xcode 构建。普通测试者可使用 [TestFlight 邀请链接](https://testflight.apple.com/join/VfB4puVJ)，能否安装取决于 Apple 审核和当前测试状态。
+开发者测试与调试产物：分发仓库的 Release 附件另提供 `scu-plus-safari-ios-unsigned.ipa`，需要使用自己的签名身份和匹配的描述文件同时重签主 App 与 Safari 扩展后安装。它是 Release 构建，原生断点调试需从源码使用 Xcode 构建。
+
+> **不建议任何不了解 IPA 的同学下载或尝试安装。** iOS/iPadOS 用户请使用上述 TestFlight 发布链接。
 
 上游新版本发布后，Safari 安装包需要等待构建、公证完成；进度见[分发构建](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。本仓库不保存 Apple 签名凭据，也不需要配置跨仓库 Secret。
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@
 
 ## Safari（macOS / iOS / iPadOS）
 
-Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Visio-Vanitas/scu-plus/releases)提供，跟随本仓库发布的版本 tag 构建，使用 Developer ID 签名并经 Apple 公证。下载对应版本的 DMG，将 SCU Plus 拖到“应用程序”，再在 Safari 设置 → 扩展中启用并授予所需网站权限。
+Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Visio-Vanitas/scu-plus/releases)提供，跟随本仓库发布的版本 tag 构建，使用 Developer ID 签名并经 Apple 公证。下载[签名 DMG](https://github.com/Visio-Vanitas/scu-plus/releases/latest/download/scu-plus-safari-macos.dmg)，将 SCU Plus 拖到“应用程序”，再在 Safari 设置 → 扩展中启用并授予所需网站权限。
 
 iOS/iPadOS：[通过 TestFlight 安装](https://testflight.apple.com/join/VfB4puVJ)。安装后在 Safari 设置中启用 SCU Plus 并授予所需网站权限；可安装版本以 Apple 审核和当前测试状态为准。
 
-开发者测试与调试产物：分发仓库的 Release 附件另提供 `scu-plus-safari-ios-unsigned.ipa`，需要使用自己的签名身份和匹配的描述文件同时重签主 App 与 Safari 扩展后安装。它是 Release 构建，原生断点调试需从源码使用 Xcode 构建。
+开发者测试与调试产物：分发仓库另提供[未签名 IPA](https://github.com/Visio-Vanitas/scu-plus/releases/latest/download/scu-plus-safari-ios-unsigned.ipa)，需要使用自己的签名身份和匹配的描述文件同时重签主 App 与 Safari 扩展后安装。它是 Release 构建，原生断点调试需从源码使用 Xcode 构建。
 
 > **不建议任何不了解 IPA 的同学下载或尝试安装。** iOS/iPadOS 用户请使用上述 TestFlight 发布链接。
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@
 
 </div>
 
-## Safari（macOS）
+## Safari（macOS / iOS / iPadOS）
 
-Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Visio-Vanitas/scu-plus/releases)提供，跟随本仓库发布的版本 tag 构建，使用 Developer ID 签名并经 Apple 公证。下载对应版本的 DMG，将 SCU Plus 拖到“应用程序”，再在 Safari 设置 → 扩展中启用并授予所需网站权限。iOS/iPadOS 暂不包含在此分发流程中。
+Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Visio-Vanitas/scu-plus/releases)提供，跟随本仓库发布的版本 tag 构建，使用 Developer ID 签名并经 Apple 公证。下载对应版本的 DMG，将 SCU Plus 拖到“应用程序”，再在 Safari 设置 → 扩展中启用并授予所需网站权限。
+
+> **不建议任何不了解 IPA 的同学下载或尝试安装。** 普通测试者请使用下方 TestFlight 入口。
+
+iOS/iPadOS：同一 Release 提供 `scu-plus-safari-ios-unsigned.ipa`，供有技术背景的同学自行重签后测试。它不能直接安装；必须使用自己的签名身份和匹配的描述文件同时重签主 App 与 Safari 扩展，再安装并在 Safari 设置中启用。该包是 Release 构建，原生断点调试需从源码使用 Xcode 构建。普通测试者可使用 [TestFlight 邀请链接](https://testflight.apple.com/join/VfB4puVJ)，能否安装取决于 Apple 审核和当前测试状态。
 
 上游新版本发布后，Safari 安装包需要等待构建、公证完成；进度见[分发构建](https://github.com/Visio-Vanitas/scu-plus/actions/workflows/safari-release-sync.yml)。本仓库不保存 Apple 签名凭据，也不需要配置跨仓库 Secret。
 
@@ -88,7 +92,7 @@ Safari 安装包由 [Visio-Vanitas/scu-plus 分发仓库](https://github.com/Vis
 | 2️⃣ **访问扩展页面** | 地址栏输入 `about:debugging#/runtime/this-firefox` |
 | 3️⃣ **加载插件** | 点击「临时载入附加组件」，选择 ZIP 文件 |
 
-> 💡 **提示**：支持 Chrome、Edge 等 Chromium 系浏览器及 Firefox，暂不支持 Safari。
+> 💡 **提示**：支持 Chrome、Edge 等 Chromium 系浏览器及 Firefox，Safari 安装方式见上方专节。
 > 📘 详细图文版请参考 [小白安装教程](https://github.com/The-Brotherhood-of-SCU/scu-plus/wiki/安装)。
 
 ---

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "plasmo dev",
     "build": "plasmo build",
+    "build:safari": "plasmo build --target=safari-mv3 --zip",
     "package": "plasmo package",
     "build:firefox:amo": "bash scripts/build-firefox-amo.sh",
     "package:amo-source": "bash scripts/package-amo-source.sh"

--- a/src/script/utils.ts
+++ b/src/script/utils.ts
@@ -16,7 +16,7 @@ declare const process: { env: { PLASMO_BROWSER?: string } };
  */
 async function checkVersion () : Promise<UpdateCheckInfo>{
     try {
-        let response = await chrome.runtime.sendMessage({ action: Actions.REQUEST, url: pkgMessage.checkForUpdateLink, accept: 'application/vnd.github+json' });
+        let response = await chrome.runtime.sendMessage({ action: Actions.REQUEST, url: process.env.PLASMO_BROWSER === 'safari' ? 'https://api.github.com/repos/Visio-Vanitas/scu-plus/releases/latest' : pkgMessage.checkForUpdateLink, accept: 'application/vnd.github+json' });
         if (!response?.success) {
             return { result: UpdateCheckResult.NETWORK_ERROR };
         }
@@ -24,6 +24,14 @@ async function checkVersion () : Promise<UpdateCheckInfo>{
         const latestVersion = (release.tag_name ?? "").replace(/^v/i, "");
         if (!latestVersion || latestVersion === pkgMessage.version) {
             return { result: UpdateCheckResult.UP_TO_DATE };
+        }
+        // Safari 的正式安装包由独立仓库签名和公证；不下载其他浏览器的 ZIP。
+        if (process.env.PLASMO_BROWSER === 'safari') {
+            return {
+                result: UpdateCheckResult.NEW_VERSION_AVAILABLE,
+                latestVersion,
+                downloadUrl: release.html_url ?? 'https://github.com/Visio-Vanitas/scu-plus/releases'
+            };
         }
         // 从 release 附件中找对应浏览器的 zip 包，下载链接加 gh-proxy 前缀加速；找不到附件则回退到 release 页面
         const assets: { name?: string; browser_download_url?: string }[] = Array.isArray(release.assets) ? release.assets : [];

--- a/tests/safari-update.test.mjs
+++ b/tests/safari-update.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import vm from "node:vm"
+import { test } from "node:test"
+import ts from "typescript"
+
+const source = readFileSync(new URL("../src/script/utils.ts", import.meta.url), "utf8")
+const code = ts.transpileModule(source, { compilerOptions: {
+  module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, esModuleInterop: true
+} }).outputText
+const releaseUrl = "https://github.com/The-Brotherhood-of-SCU/scu-plus/releases/tag/v9.0.0"
+const asset = (name) => ({ name, browser_download_url: `https://github.com/example/releases/download/v9.0.0/${name}` })
+
+async function check(browser, assets) {
+  const context = vm.createContext({
+    exports: {}, console, process: { env: { PLASMO_BROWSER: browser } },
+    require: (path) => {
+      if (path.includes("package.json")) return { version: "2.3.3", checkForUpdateLink: "https://api.github.com/repos/The-Brotherhood-of-SCU/scu-plus/releases/latest", downloadProxyPrefix: "https://gh-proxy.org/" }
+      if (path.includes("types")) return { UpdateCheckResult: { NEW_VERSION_AVAILABLE: 0, NETWORK_ERROR: 2 } }
+      if (path.includes("actions")) return { Actions: { REQUEST: "request" } }
+      return {}
+    },
+    chrome: { runtime: { sendMessage: async (message) => { assert.equal(message.url, browser === "safari" ? "https://api.github.com/repos/Visio-Vanitas/scu-plus/releases/latest" : "https://api.github.com/repos/The-Brotherhood-of-SCU/scu-plus/releases/latest"); return ({ success: true, data: JSON.stringify({ tag_name: "v9.0.0", html_url: releaseUrl, assets }) }); } } }
+  })
+  vm.runInContext(code, context)
+  return context.exports.checkVersion()
+}
+
+test("Safari without a Safari asset links to the release, not a Chromium or source ZIP", async () => {
+  const result = await check("safari", [asset("chrome-mv3-prod.zip"), asset("scu-plus-source-v9.0.0.zip")])
+  assert.equal(result.downloadUrl, releaseUrl)
+})
+for (const browser of ["chrome", "firefox"]) {
+  test(`${browser} selects only its own production archive`, async () => {
+    const result = await check(browser, [asset("scu-plus-source-v9.0.0.zip"), ...["chrome", "firefox", "safari"].map((b) => asset(`${b}-mv3-prod.zip`))])
+    assert.equal(result.downloadUrl, `https://gh-proxy.org/https://github.com/example/releases/download/v9.0.0/${browser}-mv3-prod.zip`)
+  })
+}


### PR DESCRIPTION
为 Safari 增加构建和安装入口：macOS 链接到独立分发仓库的签名公证 DMG，iOS/iPadOS 使用 [TestFlight 发布链接](https://testflight.apple.com/join/VfB4puVJ)。可安装的 iOS 版本以 Apple 审核和当前测试状态为准。

改动范围：
- 增加 `pnpm build:safari`，生成开发用 Safari MV3 ZIP。
- 发布说明模板为 DMG 和 IPA 构造 `releases/download/vX.Y.Z/文件名` 直链（README 使用 `releases/latest/download/文件名`），并按版本链接到 [子仓库的同名 Release](https://github.com/Visio-Vanitas/scu-plus/releases)，提示异步构建的等待状态，并提供 iOS/iPadOS TestFlight 入口。
- Release 附件另提供面向开发者的[未签名 IPA](https://github.com/Visio-Vanitas/scu-plus/releases/download/v2.3.3/scu-plus-safari-ios-unsigned.ipa)，需要自行重签主应用与 Safari 扩展；它不是普通用户安装入口。README 和发布说明醒目标注：**不建议任何不了解 IPA 的同学下载或尝试安装。** 原生断点调试需从源码构建。
- Safari 更新检查使用子仓库并打开分发页面；Chrome / Firefox 保持原更新来源和下载行为。
- 补充 README、Unreleased changelog 和针对性更新路由测试。

签名、公证、iOS 打包及自动分发仅在子仓库维护；上游无需 Apple 证书、跨仓库 Secret 或新增发布任务。本 PR 不包含 beta 版本号变更、原生工程或其他功能修复，不依赖 Draft PR #48。

验证：
- 3 项更新路由测试通过；发布说明生成结果包含 `v2.3.3` 子仓库链接、TestFlight 入口和 IPA 提示。
- [先前本分支独立构建检查](https://github.com/Visio-Vanitas/scu-plus/actions/runs/34304546624)通过针对性测试与 Chrome / Firefox / Safari 生产构建；本次补充只修改文档和发布说明模板。
- [v2.3.3 Release](https://github.com/Visio-Vanitas/scu-plus/releases/tag/v2.3.3)已有签名公证 macOS DMG；未签名 IPA 从[成功上传 TestFlight 的同一构建 archive](https://github.com/Visio-Vanitas/scu-plus/actions/runs/34307664975)封装。已验证包结构、版本、Safari 扩展资源，以及主应用和扩展均不含代码签名或描述文件；尚未验证用户自行重签后的 iOS 真机安装。
- 先前 macOS Safari 0.0.1 beta 真机测试由使用者确认通过，不将其等同于本 PR 每项功能均已实测。

可选的管理员接入：子仓库现每 15 分钟检查上游 Release，合并无需配置。若希望发布后立即构建，可由上游 `release: published` 工作流调用子仓库 `safari-release-sync.yml` 的 `workflow_dispatch` 并传入 tag；TestFlight 对应 `safari-testflight.yml`。凭据限定子仓库并授予 `Actions: write`。无需 Apple 签名 Secrets 或上游写权限。原生 webhook 需要另行部署验签转发服务，目前未部署；已有 `repository_dispatch` 入口也可使用，但 GitHub 要求令牌具有子仓库 `Contents: write`。
